### PR TITLE
[🔬 setting] 프로젝트 엔티티 설계 & 연관관계 매핑

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,6 @@
 
 
 # ✅ PR check list
-- [ ] Reviews
+- [ ] Reviewers
 - [ ] Assignees
 - [ ] Labels

--- a/src/main/java/org/terning/TerningApplication.java
+++ b/src/main/java/org/terning/TerningApplication.java
@@ -2,8 +2,10 @@ package org.terning;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TerningApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/terning/domain/Messages.java
+++ b/src/main/java/org/terning/domain/Messages.java
@@ -25,5 +25,4 @@ public class Messages extends BaseEntity {
     private String mainMessage;
 
     private String subMessage;
-
 }

--- a/src/main/java/org/terning/domain/Messages.java
+++ b/src/main/java/org/terning/domain/Messages.java
@@ -1,0 +1,28 @@
+package org.terning.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.terning.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Messages extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String mainMessage;
+
+    private String subMessage;
+}

--- a/src/main/java/org/terning/domain/Messages.java
+++ b/src/main/java/org/terning/domain/Messages.java
@@ -25,4 +25,5 @@ public class Messages extends BaseEntity {
     private String mainMessage;
 
     private String subMessage;
+
 }

--- a/src/main/java/org/terning/domain/Notifications.java
+++ b/src/main/java/org/terning/domain/Notifications.java
@@ -1,0 +1,27 @@
+package org.terning.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.terning.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notifications extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime schedule;
+}

--- a/src/main/java/org/terning/domain/Notifications.java
+++ b/src/main/java/org/terning/domain/Notifications.java
@@ -32,7 +32,7 @@ public class Notifications extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users users;
+    private User user;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "message_id")

--- a/src/main/java/org/terning/domain/Notifications.java
+++ b/src/main/java/org/terning/domain/Notifications.java
@@ -1,9 +1,14 @@
 package org.terning.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,4 +29,13 @@ public class Notifications extends BaseEntity {
     private Long id;
 
     private LocalDateTime schedule;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users users;
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Messages messages;
+
 }

--- a/src/main/java/org/terning/domain/Notifications.java
+++ b/src/main/java/org/terning/domain/Notifications.java
@@ -24,12 +24,6 @@ import org.terning.domain.common.BaseEntity;
 @AllArgsConstructor
 public class Notifications extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    private LocalDateTime schedule;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -38,4 +32,9 @@ public class Notifications extends BaseEntity {
     @JoinColumn(name = "message_id")
     private Messages messages;
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime schedule;
 }

--- a/src/main/java/org/terning/domain/Scraps.java
+++ b/src/main/java/org/terning/domain/Scraps.java
@@ -1,9 +1,12 @@
 package org.terning.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,5 +25,7 @@ public class Scraps extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
 }

--- a/src/main/java/org/terning/domain/Scraps.java
+++ b/src/main/java/org/terning/domain/Scraps.java
@@ -27,5 +27,5 @@ public class Scraps extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users user;
+    private Users users;
 }

--- a/src/main/java/org/terning/domain/Scraps.java
+++ b/src/main/java/org/terning/domain/Scraps.java
@@ -27,5 +27,5 @@ public class Scraps extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users users;
+    private User user;
 }

--- a/src/main/java/org/terning/domain/Scraps.java
+++ b/src/main/java/org/terning/domain/Scraps.java
@@ -1,0 +1,26 @@
+package org.terning.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.terning.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Scraps extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+}

--- a/src/main/java/org/terning/domain/Scraps.java
+++ b/src/main/java/org/terning/domain/Scraps.java
@@ -21,11 +21,11 @@ import org.terning.domain.common.BaseEntity;
 @AllArgsConstructor
 public class Scraps extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 }

--- a/src/main/java/org/terning/domain/User.java
+++ b/src/main/java/org/terning/domain/User.java
@@ -29,10 +29,10 @@ import org.terning.domain.enums.State;
 public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
-    private List<Notifications> notificationList = new ArrayList<>();
+    private List<Notifications> notifications = new ArrayList<>();
 
     @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
-    private List<Scraps> scrapList = new ArrayList<>();
+    private List<Scraps> scraps = new ArrayList<>();
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/terning/domain/User.java
+++ b/src/main/java/org/terning/domain/User.java
@@ -28,10 +28,10 @@ import org.terning.domain.enums.State;
 @Table(name = "users")
 public class User extends BaseEntity {
 
-    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Notifications> notifications = new ArrayList<>();
 
-    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Scraps> scraps = new ArrayList<>();
 
     @Id

--- a/src/main/java/org/terning/domain/User.java
+++ b/src/main/java/org/terning/domain/User.java
@@ -28,6 +28,12 @@ import org.terning.domain.enums.State;
 @Table(name = "users")
 public class User extends BaseEntity {
 
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<Notifications> notificationList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<Scraps> scrapList = new ArrayList<>();
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -43,10 +49,4 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private State state;
-
-    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
-    private List<Notifications> notificationList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
-    private List<Scraps> scrapList = new ArrayList<>();
 }

--- a/src/main/java/org/terning/domain/User.java
+++ b/src/main/java/org/terning/domain/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -24,7 +25,8 @@ import org.terning.domain.enums.State;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Users extends BaseEntity {
+@Table(name = "users")
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/terning/domain/Users.java
+++ b/src/main/java/org/terning/domain/Users.java
@@ -1,11 +1,15 @@
 package org.terning.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,4 +42,9 @@ public class Users extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private State state;
 
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<Notifications> notificationList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL)
+    private List<Scraps> scrapList = new ArrayList<>();
 }

--- a/src/main/java/org/terning/domain/Users.java
+++ b/src/main/java/org/terning/domain/Users.java
@@ -1,0 +1,41 @@
+package org.terning.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.terning.domain.common.BaseEntity;
+import org.terning.domain.enums.AuthType;
+import org.terning.domain.enums.State;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Users extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String Token;
+
+    private boolean isPushEnable;
+
+    @Enumerated(EnumType.STRING)
+    private AuthType authType;
+
+    @Enumerated(EnumType.STRING)
+    private State state;
+
+}

--- a/src/main/java/org/terning/domain/common/BaseEntity.java
+++ b/src/main/java/org/terning/domain/common/BaseEntity.java
@@ -1,0 +1,21 @@
+package org.terning.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/terning/domain/enums/AuthType.java
+++ b/src/main/java/org/terning/domain/enums/AuthType.java
@@ -1,0 +1,5 @@
+package org.terning.domain.enums;
+
+public enum AuthType {
+    APPLE, KAKAO
+}

--- a/src/main/java/org/terning/domain/enums/State.java
+++ b/src/main/java/org/terning/domain/enums/State.java
@@ -1,0 +1,5 @@
+package org.terning.domain.enums;
+
+public enum State {
+    LOGIN, LOGOUT
+}


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #2 

# 📄 Work Description
프로젝트 도메인 엔티티를 설계하고, 테이블 간 연관관계를 매핑했습니다!


# 💬 To Reviewers
- Notifications 테이블 과 Messages 테이블은 1:1 매핑으로 Message를 주인으로 설정해 Notifications 테이블에서 키를 가지고 있도록 설계했습니다.

- 또한 Notifications 테이블 항목이 삭제되면, 연관된 Messages의 항목이 삭제되도록 옵션을 설정했습니다. 이유는 해당 메시지를 보내던 푸시알림 항목을 삭제할 경우, 더이상 해당 메시지를 남겨놓을 필요가 없다고 판단했기 때문입니다.

- 해당 알림서버의 패키징 구조를 어떻게 가져갈지에 대한 고민이 있는데요, 이에 대해 의견있으시면 말씀주시면 감사하겠습니다!! :)



# 📷 Screenshot

### 도메인 구조
<img width="452" alt="image" src="https://github.com/user-attachments/assets/8a84d3cb-cc36-449a-adf0-443cf96c564d" />

### Postgres 로컬 DB 제대로 생성되었는지 확인했습니다.
<img width="349" alt="image" src="https://github.com/user-attachments/assets/9e4187ed-1a4b-40cb-9024-b491783a4abf" />



# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
