### PR TITLE
[✨ feat] UserName에 커스텀 예외처리 적용 

### DIFF
--- a/src/main/java/org/terning/user/common/failure/UserErrorCode.java
+++ b/src/main/java/org/terning/user/common/failure/UserErrorCode.java
@@ -1,0 +1,31 @@
+package org.terning.user.common.failure;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.terning.global.failure.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    USER_NAME_NOT_NULL(HttpStatus.BAD_REQUEST, "이름은 null일 수 없습니다."),
+    USER_NAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "이름은 공백 포함 12글자를 넘을 수 없습니다."),
+    INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "이름의 구성은 문자(한글, 영어), 숫자만 가능합니다."),
+    ;
+
+    private static final String PREFIX = "[USER ERROR] ";
+    public static final int NAME_MAX_LENGTH = 12;
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/org/terning/user/common/failure/UserException.java
+++ b/src/main/java/org/terning/user/common/failure/UserException.java
@@ -1,0 +1,9 @@
+package org.terning.user.common.failure;
+
+import org.terning.global.failure.BaseException;
+
+public class UserException extends BaseException {
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/terning/user/domain/vo/UserName.java
+++ b/src/main/java/org/terning/user/domain/vo/UserName.java
@@ -2,11 +2,12 @@ package org.terning.user.domain.vo;
 
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
 
 @Embeddable
 @EqualsAndHashCode
 public class UserName {
-
     private static final int NAME_MAX_LENGTH = 12;
     private static final String NAME_REGEX = "^[a-zA-Z0-9가-힣 ]*$";
 
@@ -29,8 +30,6 @@ public class UserName {
         return name;
     }
 
-    // TODO: UserException 클래스를 만들어서 BaseException을 상속받아서 사용하도록 수정
-    // TODO: BaseException 구현 및 global 예외처리 구현
     private void validateName(String name) {
         validateNull(name);
         validateLength(name);
@@ -39,19 +38,19 @@ public class UserName {
 
     private void validateNull(String name) {
         if (name == null) {
-            throw new IllegalArgumentException("이름은 null일 수 없습니다.");
+            throw new UserException(UserErrorCode.USER_NAME_NOT_NULL);
         }
     }
 
     private void validateLength(String name) {
         if (name.length() > NAME_MAX_LENGTH) {
-            throw new IllegalArgumentException("이름의 길이는 12자를 초과할 수 없습니다.");
+            throw new UserException(UserErrorCode.USER_NAME_LENGTH_EXCEEDED);
         }
     }
 
     private void validateInvalidCharacters(String name) {
         if (!name.matches(NAME_REGEX)) {
-            throw new IllegalArgumentException("이름의 구성은 문자(한글, 영어), 숫자만 가능합니다.");
+            throw new UserException(UserErrorCode.INVALID_USER_NAME);
         }
     }
 

--- a/src/test/java/org/terning/user/vo/UserNameTest.java
+++ b/src/test/java/org/terning/user/vo/UserNameTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
 import org.terning.user.domain.vo.UserName;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -113,8 +115,8 @@ class UserNameTest {
 
             // When & Then
             assertThatThrownBy(() -> UserName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름은 null일 수 없습니다.");
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.USER_NAME_NOT_NULL.getMessage());
         }
 
         @Test
@@ -125,8 +127,8 @@ class UserNameTest {
 
             // When & Then
             assertThatThrownBy(() -> UserName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름의 길이는 12자를 초과할 수 없습니다.");
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.USER_NAME_LENGTH_EXCEEDED.getMessage());
         }
 
         @Test
@@ -137,8 +139,8 @@ class UserNameTest {
 
             // When & Then
             assertThatThrownBy(() -> UserName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름의 길이는 12자를 초과할 수 없습니다.");
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.USER_NAME_LENGTH_EXCEEDED.getMessage());
         }
 
         @Test
@@ -149,8 +151,8 @@ class UserNameTest {
 
             // When & Then
             assertThatThrownBy(() -> UserName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름의 길이는 12자를 초과할 수 없습니다.");
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.USER_NAME_LENGTH_EXCEEDED.getMessage());
         }
 
         @Test
@@ -161,8 +163,8 @@ class UserNameTest {
 
             // When & Then
             assertThatThrownBy(() -> UserName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름의 길이는 12자를 초과할 수 없습니다.");
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.USER_NAME_LENGTH_EXCEEDED.getMessage());
         }
 
         @ParameterizedTest
@@ -170,8 +172,8 @@ class UserNameTest {
         @ValueSource(strings = {"jang_soon", "터닝@name", "hello#world", "test!", "name%"})
         void shouldThrowExceptionForSpecialCharacters(String invalidName) {
             assertThatThrownBy(() -> UserName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름의 구성은 문자(한글, 영어), 숫자만 가능합니다.");
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.INVALID_USER_NAME.getMessage());
         }
 
         @ParameterizedTest
@@ -179,8 +181,8 @@ class UserNameTest {
         @ValueSource(strings = {"이름\t입력", "이름\n입력", "이름\r입력", "이름\b입력"})
         void shouldThrowExceptionForControlCharacters(String invalidName) {
             assertThatThrownBy(() -> UserName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름의 구성은 문자(한글, 영어), 숫자만 가능합니다.");
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.INVALID_USER_NAME.getMessage());
         }
 
         @Test
@@ -191,8 +193,8 @@ class UserNameTest {
 
             // When & Then
             assertThatThrownBy(() -> UserName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름의 구성은 문자(한글, 영어), 숫자만 가능합니다.");
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.INVALID_USER_NAME.getMessage());
         }
     }
 }


### PR DESCRIPTION
# 📄 Work Description
- 사용자 이름 관련 예외 상황에 대한 `UserErrorCode` 구현
  - 이름이 null인 경우
  - 이름 길이가 12자를 초과하는 경우
  - 이름에 허용되지 않은 특수문자가 포함된 경우
- 사용자 도메인 전용 예외 클래스인 `UserException` 구현
  - `BaseException`을 상속받아 사용자 도메인 예외 처리 일원화
- `UserName` VO에서 기존 `IllegalArgumentException`을 `UserException`으로 변경하여 예외 처리 방식 개선
- 테스트 코드(`UserNameTest`)에서 예외 검증 시 `UserException`과 `UserErrorCode` 메시지를 기준으로 변경

# 💬 To Reviewers
- VO의 예외 처리에 대해 도메인 단위로 명확히 나누기 위해 `UserException`을 도입하였습니다.
- 테스트 코드 역시 `ErrorCode` 기반으로 리팩토링하여, 메시지 변경 시에도 안정적으로 테스트가 유지되도록 구성했습니다.
- 혹시 더 나은 구조나 보완점이 있다면 언제든지 편하게 말씀해 주세요! 😊

# 📷 Screenshot
![스크린샷 2025-03-26 오전 11 07 11](https://github.com/user-attachments/assets/c36220a5-fbb4-4198-aacc-1f9295381fe4)

# ⚙️ ISSUE
- closed #15

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels

