### PR TITLE
[✨ feat] FCM 토큰 VO 구현 

### DIFF
--- a/src/main/java/org/terning/user/common/failure/UserErrorCode.java
+++ b/src/main/java/org/terning/user/common/failure/UserErrorCode.java
@@ -11,6 +11,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_NAME_NOT_NULL(HttpStatus.BAD_REQUEST, "이름은 null일 수 없습니다."),
     USER_NAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "이름은 공백 포함 12글자를 넘을 수 없습니다."),
     INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "이름의 구성은 문자(한글, 영어), 숫자만 가능합니다."),
+
+    PUSH_TOKEN_NOT_NULL(HttpStatus.BAD_REQUEST, "푸시 토큰은 null일 수 없습니다."),
     ;
 
     private static final String PREFIX = "[USER ERROR] ";

--- a/src/main/java/org/terning/user/domain/User.java
+++ b/src/main/java/org/terning/user/domain/User.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.terning.user.domain.vo.PushToken;
 import org.terning.user.domain.vo.UserName;
 import org.terning.notification.domain.Notifications;
 import org.terning.global.entity.BaseEntity;
@@ -36,7 +37,9 @@ public class User extends BaseEntity {
     @AttributeOverride(name = "name", column = @Column(name = "name"))
     private UserName name;
 
-    private String token;
+    @Embedded
+    @AttributeOverride(name = "token", column = @Column(name = "token"))
+    private PushToken token;
 
     private boolean isPushEnable;
 

--- a/src/main/java/org/terning/user/domain/vo/PushToken.java
+++ b/src/main/java/org/terning/user/domain/vo/PushToken.java
@@ -1,0 +1,41 @@
+package org.terning.user.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
+
+@Embeddable
+@EqualsAndHashCode
+public class PushToken {
+
+    private final String token;
+
+    protected PushToken() {
+        this.token = null;
+    }
+    private PushToken(String token) {
+        validateToken(token);
+        this.token = token;
+    }
+
+    public static PushToken from(String token) {
+        return new PushToken(token);
+    }
+
+    // TODO: 추후 토큰 환경이 구축되면 토큰 데이터에 대한 비즈니스 로직 검증 추가
+    // TODO: 해당 비즈니스 로직 테스트 코드 추가
+    private void validateToken(String token) {
+        validateNull(token);
+    }
+
+    private void validateNull(String token) {
+        if (token == null) {
+            throw new UserException(UserErrorCode.PUSH_TOKEN_NOT_NULL);
+        }
+    }
+
+    public String value() {
+        return token;
+    }
+}

--- a/src/test/java/org/terning/user/domain/vo/PushTokenTest.java
+++ b/src/test/java/org/terning/user/domain/vo/PushTokenTest.java
@@ -1,0 +1,49 @@
+package org.terning.user.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("푸시 토큰 테스트")
+class PushTokenTest {
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("유효한 푸시 토큰으로 생성할 수 있다.")
+        void createPushTokenWithValidValue() {
+            // Given
+            String validToken = "abcdefg123456";
+
+            // When
+            PushToken pushToken = PushToken.from(validToken);
+
+            // Then
+            assertThat(pushToken.value()).isEqualTo(validToken);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @Test
+        @DisplayName("토큰이 null이면 예외가 발생한다.")
+        void shouldThrowExceptionWhenTokenIsNull() {
+            // Given
+            String nullToken = null;
+
+            // When & Then
+            assertThatThrownBy(() -> PushToken.from(nullToken))
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.PUSH_TOKEN_NOT_NULL.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/terning/user/domain/vo/UserNameTest.java
+++ b/src/test/java/org/terning/user/domain/vo/UserNameTest.java
@@ -1,4 +1,4 @@
-package org.terning.user.vo;
+package org.terning.user.domain.vo;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.terning.user.common.failure.UserErrorCode;
 import org.terning.user.common.failure.UserException;
-import org.terning.user.domain.vo.UserName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
# 📄 Work Description  
- `PushToken` VO 구현 및 도메인 적용  
  - 기존 `String token` → `PushToken token`으로 변경  
  - `@Embedded`, `@AttributeOverride`를 사용해 JPA 매핑  
  - null 검증 로직 포함 (비슷년시 검증은 추후 추가 예반)  
- `PushTokenTest` 테스트 클래스 작성  
  - 유효한 토큰 생성 테스트  
  - null 토큰에 대한 예외 검증  
- `UserNameTest` 테스트 클래스 패키지 위치 변경 (`user.vo` → `user.domain.vo`)  

# 💬 To Reviewers  
- 푸시 토큰 VO 네이밍을 `PushToken`으로 했는데, `FmcToken`(Firebase Cloud Messaging)과 고민했습니다.  
-  FCM이든 APNs든 추상화해서 표현한 이름, 가장 깔끔하고 범용적이라고 생각하여 `PushToken`이라고 하였습니다.
- 네이밍에 대해서 어떻게 생각하시나요!? 

# 📷 Screenshot  
![스크린샷 2025-03-26 오후 12 47 49](https://github.com/user-attachments/assets/b2fb3e9d-bfc0-40a3-b88f-7f440c82cda8)

# ⚙️ ISSUE  
- closed #17 

# ✅ PR check list  
- [x] Reviewers  
- [x] Assignees  
- [x] Labels

