### PR TITLE
[✨ feat] 푸시 알람 설정 VO 구현 

### DIFF
--- a/src/main/java/org/terning/user/common/failure/UserErrorCode.java
+++ b/src/main/java/org/terning/user/common/failure/UserErrorCode.java
@@ -13,6 +13,11 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "이름의 구성은 문자(한글, 영어), 숫자만 가능합니다."),
 
     PUSH_TOKEN_NOT_NULL(HttpStatus.BAD_REQUEST, "푸시 토큰은 null일 수 없습니다."),
+
+    INVALID_PUSH_STATUS(HttpStatus.BAD_REQUEST, "푸시 상태는 ON, OFF만 가능합니다."),
+
+    ALREADY_ENABLED_PUSH_NOTIFICATION(HttpStatus.BAD_REQUEST, "이미 푸시 알림이 활성화되어 있습니다."),
+    ALREADY_DISABLED_PUSH_NOTIFICATION(HttpStatus.BAD_REQUEST, "이미 푸시 알림이 비활성화되어 있습니다."),
     ;
 
     private static final String PREFIX = "[USER ERROR] ";

--- a/src/main/java/org/terning/user/domain/User.java
+++ b/src/main/java/org/terning/user/domain/User.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.terning.user.domain.vo.PushNotificationStatus;
 import org.terning.user.domain.vo.PushToken;
 import org.terning.user.domain.vo.UserName;
 import org.terning.notification.domain.Notifications;
@@ -41,11 +42,24 @@ public class User extends BaseEntity {
     @AttributeOverride(name = "token", column = @Column(name = "token"))
     private PushToken token;
 
-    private boolean isPushEnable;
+    @Enumerated(EnumType.STRING)
+    private PushNotificationStatus pushStatus;
 
     @Enumerated(EnumType.STRING)
     private AuthType authType;
 
     @Enumerated(EnumType.STRING)
     private State state;
+
+    public boolean canReceivePushNotification() {
+        return pushStatus.canReceiveNotification();
+    }
+
+    public void enablePushNotification() {
+        this.pushStatus = pushStatus.enable();
+    }
+
+    public void disablePushNotification() {
+        this.pushStatus = pushStatus.disable();
+    }
 }

--- a/src/main/java/org/terning/user/domain/vo/PushNotificationStatus.java
+++ b/src/main/java/org/terning/user/domain/vo/PushNotificationStatus.java
@@ -1,0 +1,40 @@
+package org.terning.user.domain.vo;
+
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
+
+import java.util.Arrays;
+
+public enum PushNotificationStatus {
+    ENABLED, DISABLED;
+
+    public static PushNotificationStatus of(String name) {
+        return Arrays.stream(values())
+                .filter(status -> status.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new UserException(UserErrorCode.INVALID_PUSH_STATUS));
+    }
+
+    public static boolean isValid(String name) {
+        return Arrays.stream(values())
+                .anyMatch(status -> status.name().equalsIgnoreCase(name));
+    }
+
+    public boolean canReceiveNotification() {
+        return this == ENABLED;
+    }
+
+    public PushNotificationStatus enable() {
+        if (this == ENABLED) {
+            throw new UserException(UserErrorCode.ALREADY_ENABLED_PUSH_NOTIFICATION);
+        }
+        return ENABLED;
+    }
+
+    public PushNotificationStatus disable() {
+        if (this == DISABLED) {
+            throw new UserException(UserErrorCode.ALREADY_DISABLED_PUSH_NOTIFICATION);
+        }
+        return DISABLED;
+    }
+}

--- a/src/test/java/org/terning/user/domain/vo/PushNotificationStatusTest.java
+++ b/src/test/java/org/terning/user/domain/vo/PushNotificationStatusTest.java
@@ -1,0 +1,105 @@
+package org.terning.user.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("푸시 알림 상태(PushNotificationStatus) 테스트")
+class PushNotificationStatusTest {
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "enable", "disable", "on", "off", "true", "false", "null", " "})
+        @DisplayName("유효하지 않은 문자열로 of() 호출 시 예외 발생")
+        void invalidStringThrowsException(String input) {
+            assertThatThrownBy(() -> PushNotificationStatus.of(input))
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.INVALID_PUSH_STATUS.getMessage());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "enable", "disable", "on", "off", "true", "false", "null", " "})
+        @DisplayName("유효하지 않은 문자열은 isValid()가 false를 반환한다")
+        void invalidStringReturnsFalse(String input) {
+            assertThat(PushNotificationStatus.isValid(input)).isFalse();
+        }
+
+        @Test
+        @DisplayName("ENABLED 상태에서 enable() 호출 시 예외 발생")
+        void enableWhenAlreadyEnabledThrowsException() {
+            assertThatThrownBy(() -> PushNotificationStatus.ENABLED.enable())
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.ALREADY_ENABLED_PUSH_NOTIFICATION.getMessage());
+        }
+
+        @Test
+        @DisplayName("DISABLED 상태에서 disable() 호출 시 예외 발생")
+        void disableWhenAlreadyDisabledThrowsException() {
+            assertThatThrownBy(() -> PushNotificationStatus.DISABLED.disable())
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.ALREADY_DISABLED_PUSH_NOTIFICATION.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ENABLED", "enabled", "EnAbLeD"})
+        @DisplayName("유효한 문자열로 PushNotificationStatus.ENABLED를 생성할 수 있다")
+        void createEnabledFromValidStrings(String input) {
+            assertThat(PushNotificationStatus.of(input)).isEqualTo(PushNotificationStatus.ENABLED);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"DISABLED", "disabled", "DisAbLed"})
+        @DisplayName("유효한 문자열로 PushNotificationStatus.DISABLED를 생성할 수 있다")
+        void createDisabledFromValidStrings(String input) {
+            assertThat(PushNotificationStatus.of(input)).isEqualTo(PushNotificationStatus.DISABLED);
+        }
+
+        @Test
+        @DisplayName("ENABLED 상태일 때 canReceiveNotification은 true를 반환한다")
+        void canReceiveNotificationWhenEnabled() {
+            assertThat(PushNotificationStatus.ENABLED.canReceiveNotification()).isTrue();
+        }
+
+        @Test
+        @DisplayName("DISABLED 상태일 때 canReceiveNotification은 false를 반환한다")
+        void canNotReceiveNotificationWhenDisabled() {
+            assertThat(PushNotificationStatus.DISABLED.canReceiveNotification()).isFalse();
+        }
+
+        @Test
+        @DisplayName("DISABLED 상태에서 enable() 호출 시 ENABLED로 전환된다")
+        void changeToEnabledFromDisabled() {
+            PushNotificationStatus result = PushNotificationStatus.DISABLED.enable();
+            assertThat(result).isEqualTo(PushNotificationStatus.ENABLED);
+        }
+
+        @Test
+        @DisplayName("ENABLED 상태에서 disable() 호출 시 DISABLED로 전환된다")
+        void changeToDisabledFromEnabled() {
+            PushNotificationStatus result = PushNotificationStatus.ENABLED.disable();
+            assertThat(result).isEqualTo(PushNotificationStatus.DISABLED);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ENABLED", "DISABLED", "enabled", "disabled"})
+        @DisplayName("유효한 문자열은 isValid()가 true를 반환한다")
+        void validStringReturnsTrue(String input) {
+            assertThat(PushNotificationStatus.isValid(input)).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- 푸시 알림 설정 상태를 단순 boolean 필드에서 `PushNotificationStatus` enum 타입으로 리팩토링 및 구현
- `User` 도메인에 `pushStatus` 필드 추가 및 관련 메서드 구현
  - `enablePushNotification()`
  - `disablePushNotification()`
  - `canReceivePushNotification()`
- `PushNotificationStatus` Enum 구현
  - 상태값: `ENABLED`, `DISABLED`
  - 문자열 파싱 메서드: `of(String)`, `isValid(String)`
  - 상태 전환 메서드 및 중복 예외 처리: `enable()`, `disable()`
  - 수신 가능 여부 확인: `canReceiveNotification()`
- 관련 테스트(`PushNotificationStatusTest`) 구현
  - 성공/실패 케이스를 나눠 상태 검증 및 전환 기능 테스트

# 💬 To Reviewers
- 기존에는 `boolean isPushEnable`로 단순 상태만 관리했지만, 중복 활성화/비활성화 같은 상태 전환 제약이나 의미 있는 행위 추상화가 어려웠습니다.
- 이번 리팩토링을 통해 상태와 동작이 객체 안에 응집되도록 개선했습니다.
- enum 기반 구현은 상태에 이름을 부여하고, 상태 전환 제어를 도메인 내부로 캡슐화하여 유지보수성과 확장성을 높이는 데 목적이 있습니다.
- 메서드 네이밍도 전환 동작과 의미가 잘 드러나도록 `enable`, `disable`, `canReceiveNotification`으로 구성했습니다.
- 더 나은 구조나 네이밍 제안 있으시면 편하게 피드백 주세요! 😊

# 📷 Screenshot
![스크린샷 2025-03-26 오후 1 48 48](https://github.com/user-attachments/assets/e6e97ea1-32e8-4b6f-8a84-0bdc6ba87ddf)

# ⚙️ ISSUE
- closed #19 

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels

