### PR TITLE
[✨ feat] 계정 상태 VO 구현

### DIFF
--- a/src/main/java/org/terning/user/common/failure/UserErrorCode.java
+++ b/src/main/java/org/terning/user/common/failure/UserErrorCode.java
@@ -18,6 +18,8 @@ public enum UserErrorCode implements ErrorCode {
 
     ALREADY_ENABLED_PUSH_NOTIFICATION(HttpStatus.BAD_REQUEST, "이미 푸시 알림이 활성화되어 있습니다."),
     ALREADY_DISABLED_PUSH_NOTIFICATION(HttpStatus.BAD_REQUEST, "이미 푸시 알림이 비활성화되어 있습니다."),
+
+    INVALID_ACCOUNT_STATUS(HttpStatus.BAD_REQUEST, "계정 상태는 active, inactive, withdrawn만 가능합니다."),
     ;
 
     private static final String PREFIX = "[USER ERROR] ";

--- a/src/main/java/org/terning/user/domain/State.java
+++ b/src/main/java/org/terning/user/domain/State.java
@@ -1,5 +1,0 @@
-package org.terning.user.domain;
-
-public enum State {
-    LOGIN, LOGOUT
-}

--- a/src/main/java/org/terning/user/domain/User.java
+++ b/src/main/java/org/terning/user/domain/User.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.terning.user.domain.vo.AccountStatus;
 import org.terning.user.domain.vo.PushNotificationStatus;
 import org.terning.user.domain.vo.PushToken;
 import org.terning.user.domain.vo.UserName;
@@ -49,7 +50,7 @@ public class User extends BaseEntity {
     private AuthType authType;
 
     @Enumerated(EnumType.STRING)
-    private State state;
+    private AccountStatus accountStatus;
 
     public boolean canReceivePushNotification() {
         return pushStatus.canReceiveNotification();
@@ -61,5 +62,9 @@ public class User extends BaseEntity {
 
     public void disablePushNotification() {
         this.pushStatus = pushStatus.disable();
+    }
+
+    public boolean isActiveUser() {
+        return !accountStatus.isWithdrawn();
     }
 }

--- a/src/main/java/org/terning/user/domain/vo/AccountStatus.java
+++ b/src/main/java/org/terning/user/domain/vo/AccountStatus.java
@@ -1,37 +1,50 @@
 package org.terning.user.domain.vo;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.terning.user.common.failure.UserErrorCode;
 import org.terning.user.common.failure.UserException;
 
 import java.util.Arrays;
 
 public enum AccountStatus {
-    LOGGED_IN,
-    LOGGED_OUT,
-    WITHDRAWN;
+    ACTIVE("active"),
+    INACTIVE("inactive"),
+    WITHDRAWN("withdrawn");
 
-    public static AccountStatus of(String name) {
+    private final String value;
+
+    AccountStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static AccountStatus from(String input) {
         return Arrays.stream(values())
-                .filter(status -> status.name().equalsIgnoreCase(name))
+                .filter(status -> status.value.equalsIgnoreCase(input))
                 .findFirst()
                 .orElseThrow(() -> new UserException(UserErrorCode.INVALID_ACCOUNT_STATUS));
     }
 
-    public static boolean isValid(String name) {
+    public static boolean isValid(String input) {
         return Arrays.stream(values())
-                .anyMatch(status -> status.name().equalsIgnoreCase(name));
+                .anyMatch(status -> status.value.equalsIgnoreCase(input));
     }
 
-    public boolean isLoggedIn() {
-        return this == LOGGED_IN;
+    public boolean isActive() {
+        return this == ACTIVE;
     }
 
-    public boolean isLoggedOut() {
-        return this == LOGGED_OUT;
+    public boolean isInactive() {
+        return this == INACTIVE;
     }
 
     public boolean isWithdrawn() {
         return this == WITHDRAWN;
     }
-}
 
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/org/terning/user/domain/vo/AccountStatus.java
+++ b/src/main/java/org/terning/user/domain/vo/AccountStatus.java
@@ -1,0 +1,37 @@
+package org.terning.user.domain.vo;
+
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
+
+import java.util.Arrays;
+
+public enum AccountStatus {
+    LOGGED_IN,
+    LOGGED_OUT,
+    WITHDRAWN;
+
+    public static AccountStatus of(String name) {
+        return Arrays.stream(values())
+                .filter(status -> status.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new UserException(UserErrorCode.INVALID_ACCOUNT_STATUS));
+    }
+
+    public static boolean isValid(String name) {
+        return Arrays.stream(values())
+                .anyMatch(status -> status.name().equalsIgnoreCase(name));
+    }
+
+    public boolean isLoggedIn() {
+        return this == LOGGED_IN;
+    }
+
+    public boolean isLoggedOut() {
+        return this == LOGGED_OUT;
+    }
+
+    public boolean isWithdrawn() {
+        return this == WITHDRAWN;
+    }
+}
+

--- a/src/test/java/org/terning/user/domain/vo/AccountStatusTest.java
+++ b/src/test/java/org/terning/user/domain/vo/AccountStatusTest.java
@@ -1,0 +1,93 @@
+package org.terning.user.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("계정 상태 테스트")
+class AccountStatusTest {
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"deleted", "invalid", " ", "로그인중"})
+        @DisplayName("AccountStatus.from(String) 호출 시 유효하지 않은 값이면 예외가 발생한다")
+        void throwsException_whenInvalidStringProvided(String input) {
+            assertThatThrownBy(() -> AccountStatus.from(input))
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.INVALID_ACCOUNT_STATUS.getMessage());
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"deleted", "invalid", " ", "로그인중"})
+        @DisplayName("AccountStatus.isValid(String)는 유효하지 않은 문자열에 대해 false를 반환한다")
+        void returnsFalse_whenInvalidInputProvided(String input) {
+            assertThat(AccountStatus.isValid(input)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @ParameterizedTest
+        @CsvSource({
+                "active, ACTIVE",
+                "inactive, INACTIVE",
+                "WITHDRAWN, WITHDRAWN"
+        })
+        @DisplayName("AccountStatus.from(String)는 대소문자 구분 없이 올바른 Enum을 반환한다")
+        void returnsCorrectEnum_whenValidStringProvided(String input, AccountStatus expected) {
+            assertThat(AccountStatus.from(input)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"active", "INACTIVE", "withdrawn"})
+        @DisplayName("AccountStatus.isValid(String)는 유효한 문자열에 대해 true를 반환한다")
+        void returnsTrue_whenValidStringProvided(String input) {
+            assertThat(AccountStatus.isValid(input)).isTrue();
+        }
+
+        @Test
+        @DisplayName("ACTIVE 상태일 때 isActive()는 true를 반환한다")
+        void isActiveReturnsTrue() {
+            assertThat(AccountStatus.ACTIVE.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("INACTIVE 상태일 때 isInactive()는 true를 반환한다")
+        void isInactiveReturnsTrue() {
+            assertThat(AccountStatus.INACTIVE.isInactive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("WITHDRAWN 상태일 때 isWithdrawn()는 true를 반환한다")
+        void isWithdrawnReturnsTrue() {
+            assertThat(AccountStatus.WITHDRAWN.isWithdrawn()).isTrue();
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "ACTIVE, active",
+                "INACTIVE, inactive",
+                "WITHDRAWN, withdrawn"
+        })
+        @DisplayName("value() 메서드는 Enum에 대응되는 문자열을 반환한다 (직렬화 값 확인)")
+        void valueMethodReturnsCorrectString(AccountStatus status, String expected) {
+            assertThat(status.value()).isEqualTo(expected);
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- 기존 `State(LOGIN, LOGOUT)` enum을 제거하고, 도메인 의도에 맞는 `AccountStatus` enum으로 전환
- `AccountStatus`는 `ACTIVE`, `INACTIVE`, `WITHDRAWN`의 세 가지 상태를 가지며,
  - 외부 표현을 위한 문자열 값(`value`) 필드를 포함하여 JSON 직렬화/역직렬화 대응
  - 상태 파싱용 `from(String)`, 유효성 검사용 `isValid(String)` 메서드 구현
  - 상태 판별용 메서드 `isActive()`, `isInactive()`, `isWithdrawn()` 추가
  - 상태 문자열 반환을 위한 `value()` 메서드 정의
- `User` 도메인에 `accountStatus` 필드를 추가하고, `isActiveUser()` 메서드 구현
- 관련 예외 상황을 처리하기 위한 `UserErrorCode.INVALID_ACCOUNT_STATUS` 항목 추가
- `AccountStatusTest`에서 상태 파싱, 유효성, 판별 메서드, 직렬화 값에 대한 테스트 케이스 구현

# 💬 To Reviewers
- 기존 `LOGIN`, `LOGOUT` 상태는 알림 기능에서의 사용자 상태를 표현하기에 부족하다고 판단하여 제거하였습니다.
- 알림의 관심사는 사용자가 '로그인했는가'보다 '알림을 보낼 수 있는 상태인지' 여부이기 때문에, 보다 의도에 맞는 상태 표현이 필요했습니다.
- 이에 따라 `ACTIVE`, `INACTIVE`, `WITHDRAWN`으로 변경하여, 도메인 책임과 표현을 명확히 구분했습니다.
- 또한 외부에 전달되는 JSON 값과 내부 enum 이름을 분리하기 위해 `value` 필드를 도입했습니다.
  - 이로 인해 직렬화/역직렬화 과정에서 의존성 분리 및 유지보수성이 향상되었습니다.
- 혹시 네이밍이나 도메인 분리에 대해 더 나은 의견 있으시면 편하게 공유해 주세요! 🙌

# 📷 Screenshot
![스크린샷 2025-03-26 오후 3 20 32](https://github.com/user-attachments/assets/948441ef-82c0-4c29-b19a-a973185ba78c)



# ⚙️ ISSUE
- closed #21 


# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels

