### PR TITLE
[♻️ refactor] 푸시 알림 상태 enum에 외부 표현 값 추가 및 구조 개선

### DIFF
--- a/src/main/java/org/terning/user/domain/vo/PushNotificationStatus.java
+++ b/src/main/java/org/terning/user/domain/vo/PushNotificationStatus.java
@@ -1,23 +1,33 @@
 package org.terning.user.domain.vo;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.terning.user.common.failure.UserErrorCode;
 import org.terning.user.common.failure.UserException;
 
 import java.util.Arrays;
 
 public enum PushNotificationStatus {
-    ENABLED, DISABLED;
+    ENABLED("enabled"),
+    DISABLED("disabled");
 
-    public static PushNotificationStatus of(String name) {
+    private final String value;
+
+    PushNotificationStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static PushNotificationStatus from(String input) {
         return Arrays.stream(values())
-                .filter(status -> status.name().equalsIgnoreCase(name))
+                .filter(status -> status.value.equalsIgnoreCase(input))
                 .findFirst()
                 .orElseThrow(() -> new UserException(UserErrorCode.INVALID_PUSH_STATUS));
     }
 
-    public static boolean isValid(String name) {
+    public static boolean isValid(String input) {
         return Arrays.stream(values())
-                .anyMatch(status -> status.name().equalsIgnoreCase(name));
+                .anyMatch(status -> status.value.equalsIgnoreCase(input));
     }
 
     public boolean canReceiveNotification() {
@@ -36,5 +46,10 @@ public enum PushNotificationStatus {
             throw new UserException(UserErrorCode.ALREADY_DISABLED_PUSH_NOTIFICATION);
         }
         return DISABLED;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
     }
 }

--- a/src/test/java/org/terning/user/domain/vo/PushNotificationStatusTest.java
+++ b/src/test/java/org/terning/user/domain/vo/PushNotificationStatusTest.java
@@ -11,7 +11,7 @@ import org.terning.user.common.failure.UserException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayName("푸시 알림 상태(PushNotificationStatus) 테스트")
+@DisplayName("푸시 알림 상태 테스트")
 class PushNotificationStatusTest {
 
     @Nested
@@ -20,9 +20,9 @@ class PushNotificationStatusTest {
 
         @ParameterizedTest
         @ValueSource(strings = {"", "enable", "disable", "on", "off", "true", "false", "null", " "})
-        @DisplayName("유효하지 않은 문자열로 of() 호출 시 예외 발생")
+        @DisplayName("유효하지 않은 문자열로 from() 호출 시 예외 발생")
         void invalidStringThrowsException(String input) {
-            assertThatThrownBy(() -> PushNotificationStatus.of(input))
+            assertThatThrownBy(() -> PushNotificationStatus.from(input))
                     .isInstanceOf(UserException.class)
                     .hasMessageContaining(UserErrorCode.INVALID_PUSH_STATUS.getMessage());
         }
@@ -56,17 +56,17 @@ class PushNotificationStatusTest {
     class SuccessCases {
 
         @ParameterizedTest
-        @ValueSource(strings = {"ENABLED", "enabled", "EnAbLeD"})
+        @ValueSource(strings = {"enabled", "ENABLED", "EnAbLeD"})
         @DisplayName("유효한 문자열로 PushNotificationStatus.ENABLED를 생성할 수 있다")
         void createEnabledFromValidStrings(String input) {
-            assertThat(PushNotificationStatus.of(input)).isEqualTo(PushNotificationStatus.ENABLED);
+            assertThat(PushNotificationStatus.from(input)).isEqualTo(PushNotificationStatus.ENABLED);
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {"DISABLED", "disabled", "DisAbLed"})
+        @ValueSource(strings = {"disabled", "DISABLED", "DisAbLed"})
         @DisplayName("유효한 문자열로 PushNotificationStatus.DISABLED를 생성할 수 있다")
         void createDisabledFromValidStrings(String input) {
-            assertThat(PushNotificationStatus.of(input)).isEqualTo(PushNotificationStatus.DISABLED);
+            assertThat(PushNotificationStatus.from(input)).isEqualTo(PushNotificationStatus.DISABLED);
         }
 
         @Test
@@ -96,7 +96,7 @@ class PushNotificationStatusTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = {"ENABLED", "DISABLED", "enabled", "disabled"})
+        @ValueSource(strings = {"enabled", "disabled", "ENABLED", "DISABLED"})
         @DisplayName("유효한 문자열은 isValid()가 true를 반환한다")
         void validStringReturnsTrue(String input) {
             assertThat(PushNotificationStatus.isValid(input)).isTrue();


### PR DESCRIPTION
# 📄 Work Description
- `PushNotificationStatus` enum에 외부 표현 값(`value`) 필드 추가 ("enabled", "disabled")
- `@JsonCreator`, `@JsonValue`를 적용해 JSON 직렬화/역직렬화 대응 가능하도록 리팩토링
- 기존 `of()` 메서드 제거 후 외부 문자열 파싱을 `from()`으로 변경
- 문자열 유효성 검사도 `name`이 아닌 `value` 기준으로 처리되도록 변경
- 테스트 코드(`PushNotificationStatusTest`)에서 `from()` 기반 테스트로 전환하고,
  - 직렬화용 value 값 검증 추가
  - `isValid()` 메서드도 value 기준으로 검증하도록 수정

# 💬 To Reviewers
- 기존에는 내부 enum 이름 기반으로 상태를 판별했지만, 외부 표현과 명확히 분리하기 위해 `value` 필드를 도입했습니다.
- 이는 외부 API와의 직렬화/역직렬화 과정에서 유연성과 안정성을 높이기 위함입니다.
- 테스트 코드에서도 이를 반영하여 `from()`, `isValid()` 메서드를 사용하는 방향으로 수정했습니다.
- 구조 개선이나 네이밍 관련해서 더 나은 아이디어가 있다면 편하게 말씀해주세요! 😊

# 📷 Screenshot
![스크린샷 2025-03-26 오후 3 31 36](https://github.com/user-attachments/assets/2034eb22-0a0e-49ab-9d03-92b64c1cdf64)

# ⚙️ ISSUE
- closed #22 

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels

