### PR TITLE
[✨ feat] 소셜 로그인 타입 VO 구현 

### DIFF
--- a/src/main/java/org/terning/user/common/failure/UserErrorCode.java
+++ b/src/main/java/org/terning/user/common/failure/UserErrorCode.java
@@ -20,10 +20,11 @@ public enum UserErrorCode implements ErrorCode {
     ALREADY_DISABLED_PUSH_NOTIFICATION(HttpStatus.BAD_REQUEST, "이미 푸시 알림이 비활성화되어 있습니다."),
 
     INVALID_ACCOUNT_STATUS(HttpStatus.BAD_REQUEST, "계정 상태는 active, inactive, withdrawn만 가능합니다."),
+
+    INVALID_AUTH_TYPE(HttpStatus.BAD_REQUEST, "인증 타입은 apple, kakao만 가능합니다."),
     ;
 
     private static final String PREFIX = "[USER ERROR] ";
-    public static final int NAME_MAX_LENGTH = 12;
 
     private final HttpStatus status;
     private final String rawMessage;

--- a/src/main/java/org/terning/user/domain/AuthType.java
+++ b/src/main/java/org/terning/user/domain/AuthType.java
@@ -1,5 +1,0 @@
-package org.terning.user.domain;
-
-public enum AuthType {
-    APPLE, KAKAO
-}

--- a/src/main/java/org/terning/user/domain/User.java
+++ b/src/main/java/org/terning/user/domain/User.java
@@ -9,10 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import org.terning.user.domain.vo.AccountStatus;
-import org.terning.user.domain.vo.PushNotificationStatus;
-import org.terning.user.domain.vo.PushToken;
-import org.terning.user.domain.vo.UserName;
+import org.terning.user.domain.vo.*;
 import org.terning.notification.domain.Notifications;
 import org.terning.global.entity.BaseEntity;
 import org.terning.scrap.domain.Scraps;

--- a/src/main/java/org/terning/user/domain/vo/AuthType.java
+++ b/src/main/java/org/terning/user/domain/vo/AuthType.java
@@ -1,0 +1,37 @@
+package org.terning.user.domain.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
+
+import java.util.Arrays;
+
+public enum AuthType {
+    APPLE("apple"),
+    KAKAO("kakao");
+
+    private final String value;
+
+    AuthType(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static AuthType from(String input) {
+        return Arrays.stream(values())
+                .filter(type -> type.value.equalsIgnoreCase(input))
+                .findFirst()
+                .orElseThrow(() -> new UserException(UserErrorCode.INVALID_AUTH_TYPE));
+    }
+
+    public static boolean isValid(String input) {
+        return Arrays.stream(values())
+                .anyMatch(type -> type.value.equalsIgnoreCase(input));
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/src/test/java/org/terning/user/domain/vo/AuthTypeTest.java
+++ b/src/test/java/org/terning/user/domain/vo/AuthTypeTest.java
@@ -1,0 +1,72 @@
+package org.terning.user.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("인증 타입 테스트")
+class AuthTypeTest {
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"google", "naver", " ", "앱"})
+        @DisplayName("AuthType.from(String) 호출 시 유효하지 않은 값이면 예외가 발생한다")
+        void throwsException_whenInvalidInputProvided(String input) {
+            assertThatThrownBy(() -> AuthType.from(input))
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining(UserErrorCode.INVALID_AUTH_TYPE.getMessage());
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"google", "naver", " ", "앱"})
+        @DisplayName("AuthType.isValid(String)는 유효하지 않은 문자열에 대해 false를 반환한다")
+        void returnsFalse_whenInvalidInputProvided(String input) {
+            assertThat(AuthType.isValid(input)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @ParameterizedTest
+        @CsvSource({
+                "apple, APPLE",
+                "kakao, KAKAO"
+        })
+        @DisplayName("AuthType.from(String)는 대소문자 구분 없이 정확한 Enum을 반환한다")
+        void returnsCorrectEnum_whenValidInputProvided(String input, AuthType expected) {
+            assertThat(AuthType.from(input)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"apple", "APPLE", "kakao", "KAKAO"})
+        @DisplayName("AuthType.isValid(String)는 유효한 문자열에 대해 true를 반환한다")
+        void returnsTrue_whenValidInputProvided(String input) {
+            assertThat(AuthType.isValid(input)).isTrue();
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "APPLE, apple",
+                "KAKAO, kakao"
+        })
+        @DisplayName("value() 메서드는 Enum에 대응되는 문자열을 반환한다 (직렬화 값 확인)")
+        void valueMethodReturnsCorrectString(AuthType authType, String expectedValue) {
+            assertThat(authType.value()).isEqualTo(expectedValue);
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- 인증 타입(`AuthType`) enum 리팩토링
  - 외부 표현 문자열(`value`) 필드 추가: "apple", "kakao"
  - @JsonCreator, @JsonValue 어노테이션 적용으로 직렬화/역직렬화 대응
  - 유효하지 않은 입력에 대한 예외 처리 (`UserException` 및 `UserErrorCode.INVALID_AUTH_TYPE` 활용)
  - 문자열 기반 파싱 메서드 `from(String)` 및 유효성 검사 메서드 `isValid(String)` 구현
- 테스트 코드(`AuthTypeTest`) 작성
  - from(), isValid(), value() 메서드 동작 확인
  - 유효/무효 입력 모두에 대한 테스트 케이스 포함
- 기존의 단순 enum 클래스 제거 후 VO 기반으로 대체

# 💬 To Reviewers
- 인증 타입이 외부 요청에서 문자열로 전달되는 구조이기 때문에, enum 내부에 외부 표현을 따로 관리하도록 리팩토링했습니다.
- JSON 직렬화 대응을 위해 `@JsonCreator`, `@JsonValue` 어노테이션을 활용하여 직관적이고 안정적인 동작을 보장하고자 했습니다.
- 도메인 객체로서 역할을 갖도록 책임과 표현을 명확히 분리하였고, 테스트도 이에 맞춰 작성했습니다.
- 네이밍, 구조 혹은 추가되면 좋을 부분이 있다면 편하게 코멘트 주세요! 😊

# 📷 Screenshot
![스크린샷 2025-03-26 오후 4 20 25](https://github.com/user-attachments/assets/4333cbcb-b5de-4432-83f0-90626de8c267)


# ⚙️ ISSUE
- closed #25 


# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels

