### PR TITLE
[♻️ refactor] VO 필드명을 value로 일관성 있게 정리 

### DIFF
--- a/src/main/java/org/terning/user/domain/User.java
+++ b/src/main/java/org/terning/user/domain/User.java
@@ -33,11 +33,11 @@ public class User extends BaseEntity {
     private Long id;
 
     @Embedded
-    @AttributeOverride(name = "name", column = @Column(name = "name"))
+    @AttributeOverride(name = "value", column = @Column(name = "name"))
     private UserName name;
 
     @Embedded
-    @AttributeOverride(name = "token", column = @Column(name = "token"))
+    @AttributeOverride(name = "value", column = @Column(name = "token"))
     private PushToken token;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/terning/user/domain/vo/PushToken.java
+++ b/src/main/java/org/terning/user/domain/vo/PushToken.java
@@ -9,33 +9,34 @@ import org.terning.user.common.failure.UserException;
 @EqualsAndHashCode
 public class PushToken {
 
-    private final String token;
+    private final String value;
 
     protected PushToken() {
-        this.token = null;
-    }
-    private PushToken(String token) {
-        validateToken(token);
-        this.token = token;
+        this.value = null;
     }
 
-    public static PushToken from(String token) {
-        return new PushToken(token);
+    private PushToken(String value) {
+        validateToken(value);
+        this.value = value;
+    }
+
+    public static PushToken from(String value) {
+        return new PushToken(value);
     }
 
     // TODO: 추후 토큰 환경이 구축되면 토큰 데이터에 대한 비즈니스 로직 검증 추가
     // TODO: 해당 비즈니스 로직 테스트 코드 추가
-    private void validateToken(String token) {
-        validateNull(token);
+    private void validateToken(String value) {
+        validateNull(value);
     }
 
-    private void validateNull(String token) {
-        if (token == null) {
+    private void validateNull(String value) {
+        if (value == null) {
             throw new UserException(UserErrorCode.PUSH_TOKEN_NOT_NULL);
         }
     }
 
     public String value() {
-        return token;
+        return value;
     }
 }

--- a/src/main/java/org/terning/user/domain/vo/UserName.java
+++ b/src/main/java/org/terning/user/domain/vo/UserName.java
@@ -11,51 +11,46 @@ public class UserName {
     private static final int NAME_MAX_LENGTH = 12;
     private static final String NAME_REGEX = "^[a-zA-Z0-9가-힣 ]*$";
 
-    private final String name;
+    private final String value;
 
     protected UserName() {
-        this.name = null;
+        this.value = null;
     }
 
-    private UserName(String name) {
-        validateName(name);
-        this.name = name;
+    private UserName(String value) {
+        validateName(value);
+        this.value = value;
     }
 
-    public static UserName from(String name) {
-        return new UserName(name);
+    public static UserName from(String value) {
+        return new UserName(value);
     }
 
     public String value() {
-        return name;
+        return value;
     }
 
-    private void validateName(String name) {
-        validateNull(name);
-        validateLength(name);
-        validateInvalidCharacters(name);
+    private void validateName(String value) {
+        validateNull(value);
+        validateLength(value);
+        validateInvalidCharacters(value);
     }
 
-    private void validateNull(String name) {
-        if (name == null) {
+    private void validateNull(String value) {
+        if (value == null) {
             throw new UserException(UserErrorCode.USER_NAME_NOT_NULL);
         }
     }
 
-    private void validateLength(String name) {
-        if (name.length() > NAME_MAX_LENGTH) {
+    private void validateLength(String value) {
+        if (value.length() > NAME_MAX_LENGTH) {
             throw new UserException(UserErrorCode.USER_NAME_LENGTH_EXCEEDED);
         }
     }
 
-    private void validateInvalidCharacters(String name) {
-        if (!name.matches(NAME_REGEX)) {
+    private void validateInvalidCharacters(String value) {
+        if (!value.matches(NAME_REGEX)) {
             throw new UserException(UserErrorCode.INVALID_USER_NAME);
         }
-    }
-
-    @Override
-    public String toString() {
-        return name;
     }
 }


### PR DESCRIPTION
# 📄 Work Description
- `UserName`, `PushToken` VO 클래스 내부 필드명을 `value`로 통일
  - 기존 name, token → value로 변경하여 도메인 VO 구조 일관성 확보
  - 생성자, 검증 로직, value() 반환 메서드 등 전체 수정
- JPA 매핑을 위한 `@AttributeOverride(name = "value", ...)` 와의 정합성 맞춤
- 테스트 및 도메인 모델에서 사용하는 value 기반 접근 방식으로 리팩토링

# 💬 To Reviewers
- 내부 필드명을 `value`로 통일한 이유는 임베디드 VO 간 구조를 일관되게 맞추고, JPA 매핑 시 `@AttributeOverride`와의 충돌 없이 적용되도록 하기 위함입니다.
- 다른 VO(`PushNotificationStatus`, `AuthType`, 등`)와 동일한 구조로 변경하여, 도메인 객체로서 일관된 책임과 표현을 갖추도록 했습니다.
- 네이밍이나 구조 개선 관련해서 더 나은 아이디어가 있으시면 편하게 공유해주세요! 😊

# 📷 Screenshot
![스크린샷 2025-03-26 오후 4 36 03](https://github.com/user-attachments/assets/0435facb-7d62-4bf3-8748-f6c4fe629ed6)

# ⚙️ ISSUE
- closed #27 

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels

