### PR TITLE
[♻️ refactor] 글로벌 예외 처리 개선 

### DIFF
--- a/src/main/java/org/terning/global/failure/GlobalExceptionHandler.java
+++ b/src/main/java/org/terning/global/failure/GlobalExceptionHandler.java
@@ -24,28 +24,4 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));
     }
-
-    @ExceptionHandler(UnsupportedOperationException.class)
-    public ResponseEntity<ErrorResponse> handleNotImplemented(UnsupportedOperationException exception) {
-        ErrorCode errorCode = GlobalErrorCode.NOT_IMPLEMENTED;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
-
-    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    public ResponseEntity<ErrorResponse> handleBadGateway(HttpMediaTypeNotSupportedException exception) {
-        ErrorCode errorCode = GlobalErrorCode.BAD_GATEWAY;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
-
-    @ExceptionHandler(SocketTimeoutException.class)
-    public ResponseEntity<ErrorResponse> handleGatewayTimeout(SocketTimeoutException exception) {
-        ErrorCode errorCode = GlobalErrorCode.GATEWAY_TIMEOUT;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
 }


### PR DESCRIPTION
# 📄 Work Description

 `GlobalExceptionHandler`에서 불필요한 예외 핸들러들을 제거하고, `BaseException`과 `Exception` 처리만 남기도록 리팩토링했습니다.  
예상 가능한 예외는 `BaseException`을 통해 처리하고, 나머지 예외는 `Exception.class`에서 일괄 처리함으로써 예외 처리 흐름을 단순화하고 유지보수성을 높였습니다.

# 💬 To Reviewers
- 특정 예외(`UnsupportedOperationException`, `HttpMediaTypeNotSupportedException`, `SocketTimeoutException`)는 내부적으로 의미 있는 처리 없이 `INTERNAL_SERVER_ERROR`로 처리되므로 제거했습니다.
- 불필요한 예외 분기 없이 핵심적인 처리만 유지하는 방향으로 구성했습니다. 추가로 분리할 필요가 있는 예외가 있다면 코멘트 부탁드립니다!

# 📷 Screenshot
![스크린샷 2025-03-27 오후 12 39 13](https://github.com/user-attachments/assets/1b637209-074e-49bc-900e-768e8d7536d7)

# ⚙️ ISSUE
- closed #30 

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
