### PR TITLE
[♻️ refactor] UserName 검증 개선

### DIFF
--- a/src/main/java/org/terning/global/failure/GlobalExceptionHandler.java
+++ b/src/main/java/org/terning/global/failure/GlobalExceptionHandler.java
@@ -24,28 +24,4 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));
     }
-
-    @ExceptionHandler(UnsupportedOperationException.class)
-    public ResponseEntity<ErrorResponse> handleNotImplemented(UnsupportedOperationException exception) {
-        ErrorCode errorCode = GlobalErrorCode.NOT_IMPLEMENTED;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
-
-    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    public ResponseEntity<ErrorResponse> handleBadGateway(HttpMediaTypeNotSupportedException exception) {
-        ErrorCode errorCode = GlobalErrorCode.BAD_GATEWAY;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
-
-    @ExceptionHandler(SocketTimeoutException.class)
-    public ResponseEntity<ErrorResponse> handleGatewayTimeout(SocketTimeoutException exception) {
-        ErrorCode errorCode = GlobalErrorCode.GATEWAY_TIMEOUT;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
 }

--- a/src/main/java/org/terning/user/common/failure/UserErrorCode.java
+++ b/src/main/java/org/terning/user/common/failure/UserErrorCode.java
@@ -10,7 +10,7 @@ import org.terning.global.failure.ErrorCode;
 public enum UserErrorCode implements ErrorCode {
     USER_NAME_NOT_NULL(HttpStatus.BAD_REQUEST, "이름은 null일 수 없습니다."),
     USER_NAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "이름은 공백 포함 12글자를 넘을 수 없습니다."),
-    INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "이름의 구성은 문자(한글, 영어), 숫자만 가능합니다."),
+    INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "이름은 한글, 영어, 숫자, 공백으로만 구성할 수 있습니다."),
 
     PUSH_TOKEN_NOT_NULL(HttpStatus.BAD_REQUEST, "푸시 토큰은 null일 수 없습니다."),
 

--- a/src/main/java/org/terning/user/domain/vo/UserName.java
+++ b/src/main/java/org/terning/user/domain/vo/UserName.java
@@ -31,12 +31,12 @@ public class UserName {
     }
 
     private void validateName(String value) {
-        validateNull(value);
-        validateLength(value);
+        validateNotNull(value);
         validateInvalidCharacters(value);
+        validateLength(value);
     }
 
-    private void validateNull(String value) {
+    private void validateNotNull(String value) {
         if (value == null) {
             throw new UserException(UserErrorCode.USER_NAME_NOT_NULL);
         }


### PR DESCRIPTION
# 📄 Work Description
- `UserName` VO에서 null 검증 메서드 이름을 `validateNull` → `validateNotNull`로 변경하여 메서드 역할을 명확히 했습니다.
- `UserErrorCode`의 에러 메시지를 상황에 맞게 개선했습니다.
  - 형식 오류 → "이름은 한글, 영어, 숫자, 공백으로만 구성할 수 있습니다."

# 💬 To Reviewers
- null 검증 자체는 기존과 동일하며, 메서드 명을 의미에 맞게 변경했습니다.
- 가독성 측면이나 메시지 표현 방식에서 더 나은 방향이 있다면 피드백 부탁드립니다 🙏

# 📷 Screenshot
![스크린샷 2025-03-27 오후 1 01 50](https://github.com/user-attachments/assets/d3d254a1-58ac-465e-9fe7-5706d12adea7)

# ⚙️ ISSUE
- closed #31

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
