### PR TITLE
[♻️ refactor] PushToken 네이밍 변경

### DIFF
--- a/src/main/java/org/terning/global/failure/GlobalExceptionHandler.java
+++ b/src/main/java/org/terning/global/failure/GlobalExceptionHandler.java
@@ -24,28 +24,4 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));
     }
-
-    @ExceptionHandler(UnsupportedOperationException.class)
-    public ResponseEntity<ErrorResponse> handleNotImplemented(UnsupportedOperationException exception) {
-        ErrorCode errorCode = GlobalErrorCode.NOT_IMPLEMENTED;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
-
-    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    public ResponseEntity<ErrorResponse> handleBadGateway(HttpMediaTypeNotSupportedException exception) {
-        ErrorCode errorCode = GlobalErrorCode.BAD_GATEWAY;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
-
-    @ExceptionHandler(SocketTimeoutException.class)
-    public ResponseEntity<ErrorResponse> handleGatewayTimeout(SocketTimeoutException exception) {
-        ErrorCode errorCode = GlobalErrorCode.GATEWAY_TIMEOUT;
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
 }

--- a/src/main/java/org/terning/user/common/failure/UserErrorCode.java
+++ b/src/main/java/org/terning/user/common/failure/UserErrorCode.java
@@ -12,7 +12,7 @@ public enum UserErrorCode implements ErrorCode {
     USER_NAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "이름은 공백 포함 12글자를 넘을 수 없습니다."),
     INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "이름은 한글, 영어, 숫자, 공백으로만 구성할 수 있습니다."),
 
-    PUSH_TOKEN_NOT_NULL(HttpStatus.BAD_REQUEST, "푸시 토큰은 null일 수 없습니다."),
+    FCM_TOKEN_NOT_NULL(HttpStatus.BAD_REQUEST, "FCM 토큰은 null일 수 없습니다."),
 
     INVALID_PUSH_STATUS(HttpStatus.BAD_REQUEST, "푸시 상태는 ON, OFF만 가능합니다."),
 

--- a/src/main/java/org/terning/user/common/failure/UserErrorCode.java
+++ b/src/main/java/org/terning/user/common/failure/UserErrorCode.java
@@ -10,7 +10,7 @@ import org.terning.global.failure.ErrorCode;
 public enum UserErrorCode implements ErrorCode {
     USER_NAME_NOT_NULL(HttpStatus.BAD_REQUEST, "이름은 null일 수 없습니다."),
     USER_NAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "이름은 공백 포함 12글자를 넘을 수 없습니다."),
-    INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "이름의 구성은 문자(한글, 영어), 숫자만 가능합니다."),
+    INVALID_USER_NAME(HttpStatus.BAD_REQUEST, "이름은 한글, 영어, 숫자, 공백으로만 구성할 수 있습니다."),
 
     PUSH_TOKEN_NOT_NULL(HttpStatus.BAD_REQUEST, "푸시 토큰은 null일 수 없습니다."),
 

--- a/src/main/java/org/terning/user/domain/User.java
+++ b/src/main/java/org/terning/user/domain/User.java
@@ -38,7 +38,7 @@ public class User extends BaseEntity {
 
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "token"))
-    private PushToken token;
+    private FcmToken token;
 
     @Enumerated(EnumType.STRING)
     private PushNotificationStatus pushStatus;

--- a/src/main/java/org/terning/user/domain/vo/FcmToken.java
+++ b/src/main/java/org/terning/user/domain/vo/FcmToken.java
@@ -7,32 +7,32 @@ import org.terning.user.common.failure.UserException;
 
 @Embeddable
 @EqualsAndHashCode
-public class PushToken {
+public class FcmToken {
 
     private final String value;
 
-    protected PushToken() {
+    protected FcmToken() {
         this.value = null;
     }
 
-    private PushToken(String value) {
+    private FcmToken(String value) {
         validateToken(value);
         this.value = value;
     }
 
-    public static PushToken from(String value) {
-        return new PushToken(value);
+    public static FcmToken from(String value) {
+        return new FcmToken(value);
     }
 
     // TODO: 추후 토큰 환경이 구축되면 토큰 데이터에 대한 비즈니스 로직 검증 추가
     // TODO: 해당 비즈니스 로직 테스트 코드 추가
     private void validateToken(String value) {
-        validateNull(value);
+        validateNotNull(value);
     }
 
-    private void validateNull(String value) {
+    private void validateNotNull(String value) {
         if (value == null) {
-            throw new UserException(UserErrorCode.PUSH_TOKEN_NOT_NULL);
+            throw new UserException(UserErrorCode.FCM_TOKEN_NOT_NULL);
         }
     }
 

--- a/src/main/java/org/terning/user/domain/vo/UserName.java
+++ b/src/main/java/org/terning/user/domain/vo/UserName.java
@@ -31,12 +31,12 @@ public class UserName {
     }
 
     private void validateName(String value) {
-        validateNull(value);
-        validateLength(value);
+        validateNotNull(value);
         validateInvalidCharacters(value);
+        validateLength(value);
     }
 
-    private void validateNull(String value) {
+    private void validateNotNull(String value) {
         if (value == null) {
             throw new UserException(UserErrorCode.USER_NAME_NOT_NULL);
         }

--- a/src/test/java/org/terning/user/domain/vo/FcmTokenTest.java
+++ b/src/test/java/org/terning/user/domain/vo/FcmTokenTest.java
@@ -9,7 +9,7 @@ import org.terning.user.common.failure.UserException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayName("푸시 토큰 테스트")
+@DisplayName("FCM 토큰 테스트")
 class FcmTokenTest {
 
     @Nested

--- a/src/test/java/org/terning/user/domain/vo/FcmTokenTest.java
+++ b/src/test/java/org/terning/user/domain/vo/FcmTokenTest.java
@@ -10,23 +10,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("푸시 토큰 테스트")
-class PushTokenTest {
+class FcmTokenTest {
 
     @Nested
     @DisplayName("성공 케이스")
     class SuccessCases {
 
         @Test
-        @DisplayName("유효한 푸시 토큰으로 생성할 수 있다.")
-        void createPushTokenWithValidValue() {
+        @DisplayName("유효한 FCM 토큰으로 생성할 수 있다.")
+        void createFcmTokenWithValidValue() {
             // Given
             String validToken = "abcdefg123456";
 
             // When
-            PushToken pushToken = PushToken.from(validToken);
+            FcmToken fcmToken = FcmToken.from(validToken);
 
             // Then
-            assertThat(pushToken.value()).isEqualTo(validToken);
+            assertThat(fcmToken.value()).isEqualTo(validToken);
         }
     }
 
@@ -35,15 +35,15 @@ class PushTokenTest {
     class FailureCases {
 
         @Test
-        @DisplayName("토큰이 null이면 예외가 발생한다.")
-        void shouldThrowExceptionWhenTokenIsNull() {
+        @DisplayName("FCM 토큰이 null이면 예외가 발생한다.")
+        void shouldThrowExceptionWhenFcmTokenIsNull() {
             // Given
             String nullToken = null;
 
             // When & Then
-            assertThatThrownBy(() -> PushToken.from(nullToken))
+            assertThatThrownBy(() -> FcmToken.from(nullToken))
                     .isInstanceOf(UserException.class)
-                    .hasMessageContaining(UserErrorCode.PUSH_TOKEN_NOT_NULL.getMessage());
+                    .hasMessageContaining(UserErrorCode.FCM_TOKEN_NOT_NULL.getMessage());
         }
     }
 }


### PR DESCRIPTION
# 📄 Work Description  
- `PushToken` 클래스명을 `FcmToken`으로 변경  
- 관련 도메인 필드(`User.token`) 및 팩토리 메서드, 생성자 명칭 일괄 변경  
- 예외 코드 `PUSH_TOKEN_NOT_NULL` → `FCM_TOKEN_NOT_NULL`로 명확히 분리  
- 테스트 클래스 DisplayName 문구를 "푸시 토큰 테스트" → "FCM 토큰 테스트"로 수정

# 💬 To Reviewers  
- 기존의 PushToken 도메인을 FCM 토큰으로 명확하게 표현하고자 리팩터링을 진행했습니다.  
- 다른 네이밍이 조금 더 적절한 표현이라고 느껴지신다면 많은 피드백 부탁드립니다! 🙏  


# 📷 Screenshot  
![스크린샷 2025-03-27 오후 1 15 17](https://github.com/user-attachments/assets/a0767ca2-0a4d-439c-a0e3-4acd1fd335c3)


# ⚙️ ISSUE  
- closed #32 

# ✅ PR check list  
- [x] Reviewers  
- [x] Assignees  
- [x] Labels

