### PR TITLE
[♻️ refactor] 메시지 포맷 로직을 내부로 이동하여 생성 책임 명확화 및 응집도 개선 

### DIFF
--- a/src/main/java/org/terning/message/domain/Message.java
+++ b/src/main/java/org/terning/message/domain/Message.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import org.terning.global.entity.BaseEntity;
 import org.terning.message.domain.enums.MessageTemplateType;
 
+import java.util.Map;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,20 +23,22 @@ public class Message extends BaseEntity {
     private MessageTemplateType messageTemplateType;
 
     private String formattedMainMessage;
-
     private String formattedSubMessage;
 
-    private Message(MessageTemplateType messageTemplateType, String formattedMainMessage, String formattedSubMessage) {
-        this.messageTemplateType = messageTemplateType;
-        this.formattedMainMessage = formattedMainMessage;
-        this.formattedSubMessage = formattedSubMessage;
+    private Message(MessageTemplateType template, String main, String sub) {
+        this.messageTemplateType = template;
+        this.formattedMainMessage = main;
+        this.formattedSubMessage = sub;
     }
 
-    public static Message of(MessageTemplateType template, String formattedMainMessage, String formattedSubMessage) {
-        return new Message(template, formattedMainMessage, formattedSubMessage);
+    public static Message of(MessageTemplateType template, Map<String, String> params) {
+        String main = template.main(params);
+        String sub = template.sub(params);
+        return new Message(template, main, sub);
     }
 
     public boolean isSameType(MessageTemplateType otherTemplate) {
         return this.messageTemplateType == otherTemplate;
     }
 }
+

--- a/src/test/java/org/terning/message/domain/MessageTest.java
+++ b/src/test/java/org/terning/message/domain/MessageTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DisplayName("메세지 도메인 테스트")
 class MessageTest {
 
-    private static final UserName VALID_USER_NAME = UserName.from("장순이");
+    private static final UserName VALID_USER_NAME = UserName.from("장순");
     private static final Map<String, String> VALID_PARAMS = Map.of("username", VALID_USER_NAME.value());
 
     @Nested
@@ -25,35 +25,32 @@ class MessageTest {
     class SuccessCases {
 
         @Test
-        @DisplayName("INTERESTED_ANNOUNCEMENT_REMINDER 메시지 포맷이 정상적으로 생성된다")
-        void formatInterestedAnnouncementReminder() {
+        @DisplayName("INTERESTED_ANNOUNCEMENT_REMINDER 메시지 생성이 정상적으로 수행된다")
+        void createInterestedAnnouncementReminderMessage() {
             MessageTemplateType template = MessageTemplateType.INTERESTED_ANNOUNCEMENT_REMINDER;
+            Message message = Message.of(template, VALID_PARAMS);
 
-            Message message = Message.of(template, template.main(null), template.sub(VALID_PARAMS));
-
-            assertThat(message.getFormattedMainMessage()).isEqualTo(template.main(null));
+            assertThat(message.getFormattedMainMessage()).isEqualTo(template.main(VALID_PARAMS));
             assertThat(message.getFormattedSubMessage()).doesNotContain("{username}");
         }
 
         @Test
-        @DisplayName("RECENTLY_POSTED_INTERNSHIP_RECOMMENDATION 메시지 포맷이 정상적으로 생성된다")
-        void formatRecentlyPostedInternshipRecommendation() {
+        @DisplayName("RECENTLY_POSTED_INTERNSHIP_RECOMMENDATION 메시지 생성이 정상적으로 수행된다")
+        void createRecentlyPostedInternshipRecommendationMessage() {
             MessageTemplateType template = MessageTemplateType.RECENTLY_POSTED_INTERNSHIP_RECOMMENDATION;
+            Message message = Message.of(template, VALID_PARAMS);
 
-            Message message = Message.of(template, template.main(null), template.sub(VALID_PARAMS));
-
-            assertThat(message.getFormattedMainMessage()).isEqualTo(template.main(null));
+            assertThat(message.getFormattedMainMessage()).isEqualTo(template.main(VALID_PARAMS));
             assertThat(message.getFormattedSubMessage()).doesNotContain("{username}");
         }
 
         @Test
-        @DisplayName("TRENDING_INTERNSHIP_ALERT 메시지 포맷이 정상적으로 생성된다")
-        void formatTrendingInternshipAlert() {
+        @DisplayName("TRENDING_INTERNSHIP_ALERT 메시지 생성이 정상적으로 수행된다")
+        void createTrendingInternshipAlertMessage() {
             MessageTemplateType template = MessageTemplateType.TRENDING_INTERNSHIP_ALERT;
+            Message message = Message.of(template, VALID_PARAMS);
 
-            Message message = Message.of(template, template.main(null), template.sub(VALID_PARAMS));
-
-            assertThat(message.getFormattedMainMessage()).isEqualTo(template.main(null));
+            assertThat(message.getFormattedMainMessage()).isEqualTo(template.main(VALID_PARAMS));
             assertThat(message.getFormattedSubMessage()).doesNotContain("{username}");
         }
 
@@ -61,7 +58,7 @@ class MessageTest {
         @DisplayName("동일한 템플릿 타입인지 확인할 수 있다")
         void checkIfSameTemplateType() {
             MessageTemplateType template = MessageTemplateType.TRENDING_INTERNSHIP_ALERT;
-            Message message = Message.of(template, template.main(null), template.sub(VALID_PARAMS));
+            Message message = Message.of(template, VALID_PARAMS);
 
             assertThat(message.isSameType(MessageTemplateType.TRENDING_INTERNSHIP_ALERT)).isTrue();
             assertThat(message.isSameType(MessageTemplateType.RECENTLY_POSTED_INTERNSHIP_RECOMMENDATION)).isFalse();
@@ -71,7 +68,10 @@ class MessageTest {
         @DisplayName("포맷이 필요 없는 템플릿은 파라미터 없이도 생성할 수 있다")
         void createWithoutParamsIfNoFormatNeeded() {
             for (MessageTemplateType template : MessageTemplateType.values()) {
+                Map<String, String> params = Map.of("username", VALID_USER_NAME.value());
                 assertThat(template.main(null)).isEqualTo(template.main(Map.of()));
+                Message message = Message.of(template, params);
+                assertThat(message).isNotNull();
             }
         }
     }
@@ -85,7 +85,7 @@ class MessageTest {
         void throwWhenMissingParams() {
             MessageTemplateType template = MessageTemplateType.TRENDING_INTERNSHIP_ALERT;
 
-            assertThatThrownBy(() -> template.sub(Map.of()))
+            assertThatThrownBy(() -> Message.of(template, Map.of()))
                     .isInstanceOf(MessageException.class)
                     .hasMessageContaining(MessageErrorCode.MISSING_FORMATTING_PARAMS.getMessage());
         }
@@ -95,7 +95,7 @@ class MessageTest {
         void throwWhenNullParams() {
             MessageTemplateType template = MessageTemplateType.RECENTLY_POSTED_INTERNSHIP_RECOMMENDATION;
 
-            assertThatThrownBy(() -> template.sub(null))
+            assertThatThrownBy(() -> Message.of(template, null))
                     .isInstanceOf(MessageException.class)
                     .hasMessageContaining(MessageErrorCode.MISSING_FORMATTING_PARAMS.getMessage());
         }
@@ -106,7 +106,7 @@ class MessageTest {
             MessageTemplateType template = MessageTemplateType.INTERESTED_ANNOUNCEMENT_REMINDER;
             Map<String, String> wrongKey = Map.of("wrong_key", VALID_USER_NAME.value());
 
-            assertThatThrownBy(() -> template.sub(wrongKey))
+            assertThatThrownBy(() -> Message.of(template, wrongKey))
                     .isInstanceOf(MessageException.class)
                     .hasMessageContaining(MessageErrorCode.MISSING_PLACEHOLDER_VALUE.getMessage());
         }
@@ -118,7 +118,7 @@ class MessageTest {
             Map<String, String> paramWithNull = new HashMap<>();
             paramWithNull.put("username", null);
 
-            assertThatThrownBy(() -> template.sub(paramWithNull))
+            assertThatThrownBy(() -> Message.of(template, paramWithNull))
                     .isInstanceOf(MessageException.class)
                     .hasMessageContaining(MessageErrorCode.MISSING_PLACEHOLDER_VALUE.getMessage());
         }


### PR DESCRIPTION
# 📄 Work Description
- Message.of(template, params) 방식으로 메시지 생성 책임을 내부로 이동함에 따라, 기존 테스트 코드 리팩토링
- 메인 메시지도 향후 포맷팅 확장을 고려하여 params를 기반으로 전달하도록 변경
- 실패 케이스 또한 Message.of() 내부에서 포맷 로직이 실행되며 예외가 발생하도록 변경

# 💬 To Reviewers
- 메인 메시지에 현재는 파라미터가 없지만, 확장을 고려해 동일한 포맷 구조를 유지했습니다
- 테스트에서 직접 포맷하지 않고 Message.of()를 통해 메시지를 생성하도록 일관성을 맞췄습니다


# 📷 Screenshot
![스크린샷 2025-03-29 오후 4 06 05](https://github.com/user-attachments/assets/298b2d44-f7f1-49ec-829f-15035e70fc5b)

# ⚙️ ISSUE
- closed #50 

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
