### PR TITLE
[✨ feat] 운영서버에서 스크랩 유저 조회 후 저장하는 동기화 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,10 @@ gradle-app.setting
 
 ## Custom
 *.idea
+
+# application.yml
 src/main/resources/application.yml
+src/main/resources/application-dev.yml
+
+# Q-Class
+src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,8 @@ java {
 	}
 }
 
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+ext {
+	queryDslVersion = '5.0.0'
 }
 
 repositories {
@@ -27,23 +25,51 @@ dependencies {
 	// Default
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// PostgreSQL
-	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
+	implementation 'org.postgresql:postgresql:42.7.3'
 
-	// Health Check
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	// WebFlux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// Firebase Admin SDK
 	implementation 'com.google.firebase:firebase-admin:9.2.0'
 
+	// QueryDSL
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// Spring Batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+}
+
+
+def queryDslSrcDir = 'src/main/generated/querydsl/'
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(queryDslSrcDir))
+}
+
+sourceSets {
+	main.java.srcDirs += [queryDslSrcDir]
+}
+
+clean {
+	delete file(queryDslSrcDir)
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }
 
 tasks.named('test') {

--- a/src/main/java/org/terning/TerningApplication.java
+++ b/src/main/java/org/terning/TerningApplication.java
@@ -1,10 +1,12 @@
 package org.terning;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableBatchProcessing
 @EnableJpaAuditing
 public class TerningApplication {
 

--- a/src/main/java/org/terning/global/config/QuerydslConfig.java
+++ b/src/main/java/org/terning/global/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package org.terning.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/terning/global/config/WebClientConfig.java
+++ b/src/main/java/org/terning/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package org.terning.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/org/terning/infra/ops/scrap/OpsScrapUserClient.java
+++ b/src/main/java/org/terning/infra/ops/scrap/OpsScrapUserClient.java
@@ -1,0 +1,25 @@
+package org.terning.infra.ops.scrap;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUsersResponse;
+
+@Component
+@RequiredArgsConstructor
+public class OpsScrapUserClient {
+
+    private final WebClient webClient;
+
+    @Value("${internal.api.scrap.unsynced}")
+    private String opsScrapUserUrl;
+
+    public OpsScrapUsersResponse fetchUnsyncedUsers() {
+        return webClient.get()
+                .uri(opsScrapUserUrl)
+                .retrieve()
+                .bodyToMono(OpsScrapUsersResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/org/terning/infra/ops/scrap/dto/response/OpsScrapUserResponse.java
+++ b/src/main/java/org/terning/infra/ops/scrap/dto/response/OpsScrapUserResponse.java
@@ -1,0 +1,7 @@
+package org.terning.infra.ops.scrap.dto.response;
+
+public record OpsScrapUserResponse(Long userId) {
+    public static OpsScrapUserResponse from(Long userId) {
+        return new OpsScrapUserResponse(userId);
+    }
+}

--- a/src/main/java/org/terning/infra/ops/scrap/dto/response/OpsScrapUsersResponse.java
+++ b/src/main/java/org/terning/infra/ops/scrap/dto/response/OpsScrapUsersResponse.java
@@ -1,0 +1,13 @@
+package org.terning.infra.ops.scrap.dto.response;
+
+import java.util.List;
+
+public record OpsScrapUsersResponse(List<OpsScrapUserResponse> users) {
+    public static OpsScrapUsersResponse of(List<Long> userIds) {
+        List<OpsScrapUserResponse> responses = userIds.stream()
+                .map(OpsScrapUserResponse::from)
+                .toList();
+
+        return new OpsScrapUsersResponse(responses);
+    }
+}

--- a/src/main/java/org/terning/scrap/api/ScrapController.java
+++ b/src/main/java/org/terning/scrap/api/ScrapController.java
@@ -1,0 +1,22 @@
+package org.terning.scrap.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.terning.scrap.application.ScrapService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/scraps")
+public class ScrapController {
+
+    private final ScrapService scrapService;
+
+    @PostMapping("/sync")
+    public ResponseEntity<Void> fetchAndSaveFromOps() {
+        scrapService.fetchAndSaveScrapUsersFromOps();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/terning/scrap/application/ScrapService.java
+++ b/src/main/java/org/terning/scrap/application/ScrapService.java
@@ -1,0 +1,17 @@
+package org.terning.scrap.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapService {
+
+    private final ScrapStatusSyncService scrapStatusSyncService;
+
+    @Transactional
+    public void fetchAndSaveScrapUsersFromOps() {
+        scrapStatusSyncService.syncScrapUsersFromOps();
+    }
+}

--- a/src/main/java/org/terning/scrap/application/ScrapStatusSyncService.java
+++ b/src/main/java/org/terning/scrap/application/ScrapStatusSyncService.java
@@ -1,0 +1,5 @@
+package org.terning.scrap.application;
+
+public interface ScrapStatusSyncService {
+    void syncScrapUsersFromOps();
+}

--- a/src/main/java/org/terning/scrap/application/ScrapStatusSyncServiceImpl.java
+++ b/src/main/java/org/terning/scrap/application/ScrapStatusSyncServiceImpl.java
@@ -1,0 +1,30 @@
+package org.terning.scrap.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.terning.infra.ops.scrap.OpsScrapUserClient;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUserResponse;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapStatusSyncServiceImpl implements ScrapStatusSyncService {
+
+    private final OpsScrapUserClient opsScrapUserClient;
+    private final ScrapSyncManager scrapSyncManager;
+
+    @Override
+    public void syncScrapUsersFromOps() {
+        List<Long> userIds = extractUserIdsFromOps();
+        if (userIds.isEmpty()) return;
+
+        scrapSyncManager.sync(userIds);
+    }
+
+    private List<Long> extractUserIdsFromOps() {
+        return opsScrapUserClient.fetchUnsyncedUsers().users().stream()
+                .map(OpsScrapUserResponse::userId)
+                .toList();
+    }
+}

--- a/src/main/java/org/terning/scrap/application/ScrapSyncManager.java
+++ b/src/main/java/org/terning/scrap/application/ScrapSyncManager.java
@@ -1,0 +1,60 @@
+package org.terning.scrap.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.terning.scrap.domain.Scrap;
+import org.terning.scrap.domain.ScrapRepository;
+import org.terning.user.domain.User;
+import org.terning.user.domain.UserRepository;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ScrapSyncManager {
+
+    private final UserRepository userRepository;
+    private final ScrapRepository scrapRepository;
+
+    public void sync(List<Long> userIds) {
+        List<Long> distinctUserIds = userIds.stream().distinct().toList();
+
+        Map<Long, User> usersById = userRepository.findUsersByIds(distinctUserIds);
+        Map<Long, Scrap> scrapsByUserId = scrapRepository.findScrapsByUserIds(distinctUserIds).stream()
+                .collect(Collectors.toMap(scrap -> scrap.getUser().getId(), Function.identity()));
+
+        List<Scrap> scrapsToPersist = distinctUserIds.stream()
+                .map(userId -> createOrUpdateScrap(userId, usersById, scrapsByUserId))
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (!scrapsToPersist.isEmpty()) {
+            scrapRepository.saveAll(scrapsToPersist);
+        }
+    }
+
+    private Scrap createOrUpdateScrap(
+            Long userId,
+            Map<Long, User> usersById,
+            Map<Long, Scrap> scrapsByUserId
+    ) {
+        User user = usersById.get(userId);
+        if (user == null) {
+            return null;
+        }
+
+        Scrap existingScrap = scrapsByUserId.get(userId);
+        if (existingScrap == null) {
+            return Scrap.of(user);
+        }
+
+        if (existingScrap.isUnscrapped()) {
+            existingScrap.scrap();
+            return existingScrap;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/terning/scrap/batch/ScrapUserSyncJobConfig.java
+++ b/src/main/java/org/terning/scrap/batch/ScrapUserSyncJobConfig.java
@@ -1,0 +1,49 @@
+package org.terning.scrap.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.terning.scrap.batch.processor.ScrapUserItemProcessor;
+import org.terning.scrap.batch.reader.ScrapUserItemReader;
+import org.terning.scrap.batch.step.ScrapSyncWriter;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUserResponse;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class ScrapUserSyncJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final ScrapUserItemReader scrapUserItemReader;
+    private final ScrapUserItemProcessor scrapUserItemProcessor;
+    private final ScrapSyncWriter scrapSyncWriter;
+
+    @Bean
+    public Job scrapUserSyncJob() {
+        return new JobBuilder("scrapUserSyncJob", jobRepository)
+                .start(scrapUserSyncStep())
+                .build();
+    }
+
+    @Bean
+    public Step scrapUserSyncStep() {
+        return new StepBuilder("s crapUserSyncStep", jobRepository)
+                .<OpsScrapUserResponse, OpsScrapUserResponse>chunk(100, transactionManager)
+                .reader(scrapUserItemReader)
+                .processor(scrapUserItemProcessor)
+                .writer(scrapSyncWriter)
+                .faultTolerant()
+                .retryLimit(3)
+                .retry(Exception.class)
+                .build();
+    }
+}

--- a/src/main/java/org/terning/scrap/batch/processor/ScrapUserItemProcessor.java
+++ b/src/main/java/org/terning/scrap/batch/processor/ScrapUserItemProcessor.java
@@ -1,0 +1,19 @@
+package org.terning.scrap.batch.processor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUserResponse;
+
+@Slf4j
+@Component
+public class ScrapUserItemProcessor implements ItemProcessor<OpsScrapUserResponse, OpsScrapUserResponse> {
+
+    private static final String LOG_PROCESSING_USER = "[스크랩 배치] 처리 대상 유저 ID: {}";
+
+    @Override
+    public OpsScrapUserResponse process(OpsScrapUserResponse item) {
+        log.debug(LOG_PROCESSING_USER, item.userId());
+        return item;
+    }
+}

--- a/src/main/java/org/terning/scrap/batch/reader/ScrapUserItemReader.java
+++ b/src/main/java/org/terning/scrap/batch/reader/ScrapUserItemReader.java
@@ -1,0 +1,37 @@
+package org.terning.scrap.batch.reader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.stereotype.Component;
+import org.terning.infra.ops.scrap.OpsScrapUserClient;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUserResponse;
+
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScrapUserItemReader implements ItemReader<OpsScrapUserResponse> {
+
+    private static final String LOG_FETCHING_USERS = "[스크랩 배치] 동기화 대상 유저 목록 조회 시작";
+
+    private final OpsScrapUserClient opsScrapUserClient;
+    private Iterator<OpsScrapUserResponse> userIterator;
+
+    @Override
+    public OpsScrapUserResponse read() {
+        if (userIterator == null) {
+            log.info(LOG_FETCHING_USERS);
+            List<OpsScrapUserResponse> users = opsScrapUserClient.fetchUnsyncedUsers().users();
+            userIterator = users.iterator();
+        }
+
+        if (userIterator.hasNext()) {
+            return userIterator.next();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/terning/scrap/batch/scheduler/ScrapUserSyncJobScheduler.java
+++ b/src/main/java/org/terning/scrap/batch/scheduler/ScrapUserSyncJobScheduler.java
@@ -1,0 +1,36 @@
+package org.terning.scrap.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScrapUserSyncJobScheduler {
+
+    private static final String LOG_JOB_SUCCESS = "[스크랩 배치] 동기화 작업 실행 완료";
+    private static final String LOG_JOB_FAIL = "[스크랩 배치] 동기화 작업 실행 실패";
+
+    private final JobLauncher jobLauncher;
+    private final Job scrapSyncJob;
+
+    @Scheduled(cron = "0 30 20 * * *")
+    public void runScrapSyncJob() {
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addLong("run.id", System.currentTimeMillis())
+                    .toJobParameters();
+
+            jobLauncher.run(scrapSyncJob, jobParameters);
+            log.info(LOG_JOB_SUCCESS);
+        } catch (Exception e) {
+            log.error(LOG_JOB_FAIL, e);
+        }
+    }
+}

--- a/src/main/java/org/terning/scrap/batch/step/ScrapSyncWriter.java
+++ b/src/main/java/org/terning/scrap/batch/step/ScrapSyncWriter.java
@@ -1,0 +1,36 @@
+package org.terning.scrap.batch.step;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUserResponse;
+import org.terning.scrap.application.ScrapSyncManager;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScrapSyncWriter implements ItemWriter<OpsScrapUserResponse> {
+
+    private static final String LOG_WRITING_USERS = "[스크랩 배치] 동기화 대상 유저 수: {}";
+
+    private final ScrapSyncManager scrapSyncManager;
+
+    @Override
+    public void write(Chunk<? extends OpsScrapUserResponse> chunk) {
+        List<Long> userIds = extractUserIdsFrom(chunk);
+        log.info(LOG_WRITING_USERS, userIds.size());
+        scrapSyncManager.sync(userIds);
+    }
+
+    private List<Long> extractUserIdsFrom(Chunk<? extends OpsScrapUserResponse> chunk) {
+        return StreamSupport.stream(chunk.spliterator(), false)
+                .map(OpsScrapUserResponse::userId)
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/java/org/terning/scrap/domain/ScrapRepository.java
+++ b/src/main/java/org/terning/scrap/domain/ScrapRepository.java
@@ -1,0 +1,9 @@
+package org.terning.scrap.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapRepositoryCustom {
+}
+

--- a/src/main/java/org/terning/scrap/domain/ScrapRepositoryCustom.java
+++ b/src/main/java/org/terning/scrap/domain/ScrapRepositoryCustom.java
@@ -1,0 +1,7 @@
+package org.terning.scrap.domain;
+
+import java.util.List;
+
+public interface ScrapRepositoryCustom {
+    List<Scrap> findScrapsByUserIds(List<Long> userIds);
+}

--- a/src/main/java/org/terning/scrap/domain/ScrapRepositoryImpl.java
+++ b/src/main/java/org/terning/scrap/domain/ScrapRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.terning.scrap.domain;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static org.terning.scrap.domain.QScrap.scrap;
+
+@Repository
+@RequiredArgsConstructor
+public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Scrap> findScrapsByUserIds(List<Long> userIds) {
+        return queryFactory
+                .selectFrom(scrap)
+                .where(scrap.user.id.in(userIds))
+                .fetch();
+    }
+}
+

--- a/src/main/java/org/terning/user/domain/UserRepository.java
+++ b/src/main/java/org/terning/user/domain/UserRepository.java
@@ -3,6 +3,6 @@ package org.terning.user.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 }
+

--- a/src/main/java/org/terning/user/domain/UserRepositoryCustom.java
+++ b/src/main/java/org/terning/user/domain/UserRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.terning.user.domain;
+
+import java.util.List;
+import java.util.Map;
+
+public interface UserRepositoryCustom {
+    Map<Long, User> findUsersByIds(List<Long> userIds);
+}
+

--- a/src/main/java/org/terning/user/domain/UserRepositoryImpl.java
+++ b/src/main/java/org/terning/user/domain/UserRepositoryImpl.java
@@ -1,0 +1,28 @@
+package org.terning.user.domain;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, User> findUsersByIds(List<Long> userIds) {
+        return queryFactory
+                .selectFrom(QUser.user)
+                .where(QUser.user.id.in(userIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+    }
+}
+

--- a/src/test/java/org/terning/scrap/application/ScrapStatusSyncServiceImplTest.java
+++ b/src/test/java/org/terning/scrap/application/ScrapStatusSyncServiceImplTest.java
@@ -1,0 +1,120 @@
+package org.terning.scrap.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.terning.infra.ops.scrap.OpsScrapUserClient;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUserResponse;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUsersResponse;
+import org.terning.scrap.domain.Scrap;
+import org.terning.scrap.domain.ScrapRepositoryTest;
+import org.terning.user.domain.UserRepositoryTest;
+import org.terning.user.domain.User;
+import org.terning.user.domain.vo.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("스크랩 상태 동기화 서비스 테스트")
+class ScrapStatusSyncServiceImplTest {
+
+    private ScrapRepositoryTest scrapRepository;
+    private UserRepositoryTest userRepository;
+    private FakeOpsScrapUserClient fakeClient;
+    private ScrapStatusSyncServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        scrapRepository = new ScrapRepositoryTest();
+        userRepository = new UserRepositoryTest();
+        fakeClient = new FakeOpsScrapUserClient();
+        ScrapSyncManager syncManager = new ScrapSyncManager(userRepository, scrapRepository);
+        service = new ScrapStatusSyncServiceImpl(fakeClient, syncManager);
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class Success {
+
+        @Test
+        @DisplayName("스크랩되지 않은 유저를 동기화한다")
+        void sync_new_scrap_users() {
+            User user = saveUser("장순", "token");
+            fakeClient.setUserIds(List.of(user.getId()));
+
+            service.syncScrapUsersFromOps();
+
+            assertThat(scrapRepository.findScrapsByUserIds(List.of(user.getId()))).hasSize(1);
+            assertThat(scrapRepository.findScrapsByUserIds(List.of(user.getId())).get(0).isScrapped()).isTrue();
+        }
+
+        @Test
+        @DisplayName("스크랩이 이미 된 유저는 건드리지 않는다")
+        void already_scrapped_user_is_ignored() {
+            User user = saveUser("장순", "token");
+            scrapRepository.save(Scrap.of(user));
+            fakeClient.setUserIds(List.of(user.getId()));
+
+            service.syncScrapUsersFromOps();
+
+            assertThat(scrapRepository.findScrapsByUserIds(List.of(user.getId()))).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 및 예외 케이스")
+    class Failure {
+
+        @Test
+        @DisplayName("운영 서버에서 유저가 없을 경우 아무 작업도 하지 않는다")
+        void skip_when_no_user_from_ops() {
+            fakeClient.setUserIds(List.of());
+
+            service.syncScrapUsersFromOps();
+
+            assertThat(scrapRepository.findAll()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("운영 서버에서 전달된 유저가 존재하지 않는 경우 무시한다")
+        void skip_when_user_not_found() {
+            fakeClient.setUserIds(List.of(999L));
+
+            service.syncScrapUsersFromOps();
+
+            assertThat(scrapRepository.findAll()).isEmpty();
+        }
+    }
+
+    private User saveUser(String name, String token) {
+        return userRepository.save(User.of(
+                UserName.from(name),
+                FcmToken.from(token),
+                PushNotificationStatus.ENABLED,
+                AuthType.KAKAO,
+                AccountStatus.ACTIVE
+        ));
+    }
+
+    static class FakeOpsScrapUserClient extends OpsScrapUserClient {
+        private List<Long> userIds;
+
+        public FakeOpsScrapUserClient() {
+            super(null);
+        }
+
+        public void setUserIds(List<Long> userIds) {
+            this.userIds = userIds;
+        }
+
+        @Override
+        public OpsScrapUsersResponse fetchUnsyncedUsers() {
+            List<OpsScrapUserResponse> responses = userIds.stream()
+                    .map(OpsScrapUserResponse::from)
+                    .toList();
+            return new OpsScrapUsersResponse(responses);
+        }
+    }
+}

--- a/src/test/java/org/terning/scrap/application/ScrapSyncManagerTest.java
+++ b/src/test/java/org/terning/scrap/application/ScrapSyncManagerTest.java
@@ -1,0 +1,109 @@
+package org.terning.scrap.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.terning.scrap.domain.*;
+import org.terning.user.domain.*;
+import org.terning.user.domain.vo.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ScrapSyncManager 단위 테스트")
+class ScrapSyncManagerTest {
+
+    private ScrapRepositoryTest scrapRepository;
+    private UserRepositoryTest userRepository;
+    private ScrapSyncManager syncManager;
+
+    @BeforeEach
+    void setUp() {
+        scrapRepository = new ScrapRepositoryTest();
+        userRepository = new UserRepositoryTest();
+        syncManager = new ScrapSyncManager(userRepository, scrapRepository);
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class Success {
+
+        @Test
+        @DisplayName("스크랩되지 않은 유저는 새로 SCRAPPED 상태로 저장된다")
+        void save_new_scrap() {
+            User user = saveUser("장순", "token");
+            Long userId = user.getId();
+
+            syncManager.sync(List.of(userId));
+
+            Scrap result = scrapRepository.findScrapsByUserIds(List.of(userId)).get(0);
+            assertThat(result.isScrapped()).isTrue();
+        }
+
+        @Test
+        @DisplayName("UNSCRAPPED 상태인 경우 SCRAPPED로 업데이트된다")
+        void update_unscrapped() {
+            User user = saveUser("장순", "token");
+            Scrap scrap = Scrap.of(user);
+            scrap.unscrap();
+            scrapRepository.save(scrap);
+
+            syncManager.sync(List.of(user.getId()));
+
+            Scrap result = scrapRepository.findScrapsByUserIds(List.of(user.getId())).get(0);
+            assertThat(result.isScrapped()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 SCRAPPED 상태인 경우 변경되지 않는다")
+        void already_scrapped() {
+            User user = saveUser("장순", "token");
+            scrapRepository.save(Scrap.of(user));
+
+            syncManager.sync(List.of(user.getId()));
+
+            List<Scrap> result = scrapRepository.findScrapsByUserIds(List.of(user.getId()));
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).isScrapped()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("실패/예외 케이스")
+    class Failure {
+
+        @Test
+        @DisplayName("유저가 존재하지 않으면 무시된다")
+        void ignore_when_user_not_found() {
+            syncManager.sync(List.of(123L));
+
+            List<Scrap> result = scrapRepository.findScrapsByUserIds(List.of(123L));
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("중복된 유저 ID가 들어와도 한 번만 처리된다")
+        void handle_duplicates_once() {
+            User user = saveUser("중복유저", "token");
+            Long userId = user.getId();
+
+            syncManager.sync(List.of(userId, userId));
+
+            List<Scrap> result = scrapRepository.findScrapsByUserIds(List.of(userId));
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).isScrapped()).isTrue();
+        }
+    }
+
+    private User saveUser(String name, String token) {
+        return userRepository.save(User.of(
+                UserName.from(name),
+                FcmToken.from(token),
+                PushNotificationStatus.ENABLED,
+                AuthType.KAKAO,
+                AccountStatus.ACTIVE
+        ));
+    }
+}

--- a/src/test/java/org/terning/scrap/batch/step/ScrapSyncWriterTest.java
+++ b/src/test/java/org/terning/scrap/batch/step/ScrapSyncWriterTest.java
@@ -1,0 +1,127 @@
+package org.terning.scrap.batch.step;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.Chunk;
+import org.terning.infra.ops.scrap.dto.response.OpsScrapUserResponse;
+import org.terning.scrap.domain.*;
+import org.terning.scrap.application.ScrapSyncManager;
+import org.terning.user.domain.*;
+import org.terning.user.domain.vo.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("스크랩 동기화 배치 Writer 테스트")
+class ScrapSyncWriterTest {
+
+    private ScrapRepositoryTest scrapRepository;
+    private UserRepositoryTest userRepository;
+    private ScrapSyncWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        scrapRepository = new ScrapRepositoryTest();
+        userRepository = new UserRepositoryTest();
+        ScrapSyncManager scrapSyncManager = new ScrapSyncManager(userRepository, scrapRepository);
+        writer = new ScrapSyncWriter(scrapSyncManager);
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class Success {
+
+        @Test
+        @DisplayName("스크랩되지 않은 유저를 새로 스크랩한다")
+        void save_new_scrap() {
+            User user = saveUser("장순", "a");
+            Long userId = user.getId();
+
+            Chunk<OpsScrapUserResponse> chunk = new Chunk<>(List.of(OpsScrapUserResponse.from(userId)));
+
+            writer.write(chunk);
+
+            Scrap saved = scrapRepository.findScrapsByUserIds(List.of(userId)).get(0);
+            assertThat(saved.isScrapped()).isTrue();
+        }
+
+        @Test
+        @DisplayName("UNSCRAPPED 상태의 스크랩을 SCRAPPED로 변경한다")
+        void update_scrap_status() {
+            User user = saveUser("장순", "a");
+            Scrap scrap = Scrap.of(user);
+            scrap.unscrap();
+            scrapRepository.save(scrap);
+
+            Chunk<OpsScrapUserResponse> chunk = new Chunk<>(List.of(OpsScrapUserResponse.from(user.getId())));
+
+            writer.write(chunk);
+
+            Scrap updated = scrapRepository.findScrapsByUserIds(List.of(user.getId())).get(0);
+            assertThat(updated.isScrapped()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 SCRAPPED 상태인 경우는 저장하지 않는다")
+        void already_scrapped_should_be_ignored() {
+            User user = saveUser("장순", "a");
+            scrapRepository.save(Scrap.of(user));
+
+            Chunk<OpsScrapUserResponse> chunk = new Chunk<>(List.of(OpsScrapUserResponse.from(user.getId())));
+
+            writer.write(chunk);
+
+            List<Scrap> scraps = scrapRepository.findScrapsByUserIds(List.of(user.getId()));
+            assertThat(scraps).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class Failure {
+
+        @Test
+        @DisplayName("존재하지 않는 유저 ID는 무시한다")
+        void ignore_if_user_not_found() {
+            Long unknownUserId = 999L;
+
+            Chunk<OpsScrapUserResponse> chunk = new Chunk<>(List.of(OpsScrapUserResponse.from(unknownUserId)));
+
+            writer.write(chunk);
+
+            List<Scrap> result = scrapRepository.findScrapsByUserIds(List.of(unknownUserId));
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("중복된 유저 ID가 들어와도 한 번만 처리된다")
+        void process_only_once_when_duplicated() {
+            User user = saveUser("중복유저", "token");
+            Long userId = user.getId();
+
+            Chunk<OpsScrapUserResponse> chunk = new Chunk<>(List.of(
+                    OpsScrapUserResponse.from(userId),
+                    OpsScrapUserResponse.from(userId)
+            ));
+
+            writer.write(chunk);
+
+            List<Scrap> result = scrapRepository.findScrapsByUserIds(List.of(userId));
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).isScrapped()).isTrue();
+        }
+    }
+
+    private User saveUser(String name, String token) {
+        return userRepository.save(User.of(
+                UserName.from(name),
+                FcmToken.from(token),
+                PushNotificationStatus.ENABLED,
+                AuthType.KAKAO,
+                AccountStatus.ACTIVE
+        ));
+    }
+}

--- a/src/test/java/org/terning/scrap/domain/ScrapRepositoryTest.java
+++ b/src/test/java/org/terning/scrap/domain/ScrapRepositoryTest.java
@@ -1,0 +1,191 @@
+package org.terning.scrap.domain;
+
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.FluentQuery;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ScrapRepositoryTest implements ScrapRepository, ScrapRepositoryCustom {
+
+    private final List<Scrap> scraps = new ArrayList<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    @Override
+    public <S extends Scrap> S save(S entity) {
+        if (entity.getId() == null) {
+            try {
+                var idField = Scrap.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(entity, idGenerator.getAndIncrement());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            deleteById(entity.getId());
+        }
+        scraps.add(entity);
+        return entity;
+    }
+
+    @Override
+    public List<Scrap> findScrapsByUserIds(List<Long> userIds) {
+        return scraps.stream()
+                .filter(scrap -> userIds.contains(scrap.getUser().getId()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Scrap> findAll() {
+        return scraps;
+    }
+
+    @Override
+    public List<Scrap> findAllById(Iterable<Long> longs) {
+        return List.of();
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        scraps.removeIf(scrap -> Objects.equals(scrap.getId(), id));
+    }
+
+    @Override
+    public void delete(Scrap entity) {
+
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Scrap> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+        scraps.clear();
+    }
+
+    @Override
+    public <S extends Scrap> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        for (S entity : entities) {
+            result.add(save(entity));
+        }
+        return result;
+    }
+
+    @Override
+    public Optional<Scrap> findById(Long aLong) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsById(Long aLong) {
+        return false;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends Scrap> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends Scrap> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<Scrap> entities) {
+
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public Scrap getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Scrap getById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Scrap getReferenceById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends Scrap> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends Scrap> List<S> findAll(Example<S> example) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends Scrap> List<S> findAll(Example<S> example, Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends Scrap> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Scrap> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends Scrap> boolean exists(Example<S> example) {
+        return false;
+    }
+
+    @Override
+    public <S extends Scrap, R> R findBy(Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+
+    @Override
+    public List<Scrap> findAll(Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public Page<Scrap> findAll(Pageable pageable) {
+        return null;
+    }
+}

--- a/src/test/java/org/terning/user/domain/UserRepositoryTest.java
+++ b/src/test/java/org/terning/user/domain/UserRepositoryTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public class UserRepositoryTest implements UserRepository {
+public class UserRepositoryTest implements UserRepository, UserRepositoryCustom {
 
     private final List<User> users = new ArrayList<>();
     private final AtomicLong idGenerator = new AtomicLong(1);
@@ -32,6 +32,13 @@ public class UserRepositoryTest implements UserRepository {
             throw new RuntimeException("[USER REPOSITORY TEST ERROR] User 객체의 id 필드를 설정할 수 없습니다.", e);
         }
         return user;
+    }
+
+    @Override
+    public Map<Long, User> findUsersByIds(List<Long> userIds) {
+        return users.stream()
+                .filter(user -> userIds.contains(user.getId()))
+                .collect(Collectors.toMap(User::getId, Function.identity()));
     }
 
     @Override


### PR DESCRIPTION
# 📄 Work Description
- 운영 서버와의 스크랩 유저 동기화를 위한 배치 작업 전체를 구현했습니다.
- 운영 서버에서 미동기화 유저 목록을 조회한 뒤, 스크랩 상태를 SCRAPPED로 반영합니다.
- 스프링 배치를 활용하여 Reader → Processor → Writer → SyncManager 흐름으로 구성하였습니다.
- **두 가지 방식으로 동기화 트리거가 가능합니다.**
  - `/api/v1/scraps/sync` API 호출 시 수동으로 동기화 실행
  - 매일 20:30에 자동으로 배치가 실행되도록 스케줄링 설정
- 1만 명 기준 30분 이내 처리 성능을 고려해 `chunkSize = 100`으로 설정했습니다.
- 테스트를 위한 인메모리 기반 리포지토리(Fake Repository) 및 유닛 테스트도 작성하였습니다.

# 💬 To Reviewers
- 동기화 로직의 확장성과 방어적 코드 작성에 초점을 맞췄습니다.
- 특히 `ScrapSyncManager`, `ScrapSyncWriter`, 배치 구성(`Job`, `Step`, `Scheduler`)의 책임 분리가 명확한지 봐주시면 감사하겠습니다 🙏
- `chunkSize`는 현재 100으로 설정했는데, 성능 기준으로 괜찮은 값인지에 대해서도 의견 주시면 좋겠습니다.
- 테스트에서는 `ScrapRepositoryTest`, `UserRepositoryTest`와 같은 테스트용 저장소를 직접 구현했는데, 이 방식에 대한 피드백도 환영합니다!
- **수동 호출 API와 자동 스케줄 배치를 병행하여 구현한 구조가 괜찮은지도 부탁드립니다.**

# 📷 Screenshot

![스크린샷 2025-03-30 오후 8 23 07](https://github.com/user-attachments/assets/aedae7da-1ae7-47dd-bac6-880523cd66be)


![스크린샷 2025-03-30 오후 8 22 23](https://github.com/user-attachments/assets/68c29a01-099e-4143-b3ca-cdc8c88430b0)


![스크린샷 2025-03-30 오후 8 22 00](https://github.com/user-attachments/assets/75366240-a501-4409-9984-b26ad34ea066)


![스크린샷 2025-03-30 오후 7 04 30](https://github.com/user-attachments/assets/132fb50d-3976-4b02-94be-f19e17787931)
![스크린샷 2025-03-30 오후 7 04 39](https://github.com/user-attachments/assets/fe813c2b-6847-4569-9c25-0eb06293ebee)


# ⚙️ ISSUE
- closed #52 

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
