### PR TITLE
[✨ feat] 알림 서버에서 유저 상태 동기화 작업 및 API 구현

### DIFF
--- a/src/main/java/org/terning/user/api/UserController.java
+++ b/src/main/java/org/terning/user/api/UserController.java
@@ -48,5 +48,31 @@ public class UserController {
         userService.createUser(request);
         return ResponseEntity.ok(SuccessResponse.of(UserSuccessCode.USER_CREATED));
     }
+
+    @PutMapping("/{userId}/push-status")
+    public ResponseEntity<SuccessResponse<Void>> updatePushStatus(
+            @PathVariable Long userId,
+            @RequestBody String newPushStatus
+    ) {
+        userService.updatePushStatus(userId, newPushStatus);
+        return ResponseEntity.ok(SuccessResponse.of(UserSuccessCode.PUSH_STATUS_UPDATED));
+    }
+
+    @PutMapping("/{userId}/name")
+    public ResponseEntity<SuccessResponse<Void>> updateUserName(
+            @PathVariable Long userId,
+            @RequestBody String newName
+    ) {
+        userService.updateUserName(userId, newName);
+        return ResponseEntity.ok(SuccessResponse.of(UserSuccessCode.USER_NAME_UPDATED));
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteUser(
+            @PathVariable Long userId
+    ) {
+        userService.deleteUser(userId);
+        return ResponseEntity.ok(SuccessResponse.of(UserSuccessCode.USER_DELETED));
+    }
 }
 

--- a/src/main/java/org/terning/user/application/UserService.java
+++ b/src/main/java/org/terning/user/application/UserService.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.terning.user.application.fcmtoken.update.FcmTokenUpdateService;
 import org.terning.user.application.fcmtoken.validate.FcmTokenValidateService;
+import org.terning.user.common.failure.UserErrorCode;
+import org.terning.user.common.failure.UserException;
 import org.terning.user.domain.User;
 import org.terning.user.domain.UserRepository;
 import org.terning.user.domain.vo.AccountStatus;
@@ -46,5 +48,28 @@ public class UserService {
                 accountStatus
         );
         userRepository.save(user);
+    }
+
+    @Transactional
+    public void updatePushStatus(Long oUserId, String newPushStatus) {
+        User user = userRepository.findByOUserId(oUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        user.setPushStatus(PushNotificationStatus.from(newPushStatus));
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateUserName(Long oUserId, String newName) {
+        User user = userRepository.findByOUserId(oUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        user.setName(UserName.from(newName));
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void deleteUser(Long oUserId) {
+        User user = userRepository.findByOUserId(oUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/org/terning/user/common/success/UserSuccessCode.java
+++ b/src/main/java/org/terning/user/common/success/UserSuccessCode.java
@@ -11,7 +11,10 @@ public enum UserSuccessCode implements SuccessCode {
 
     FCM_TOKEN_REISSUE_STATUS_PROVIDED(HttpStatus.OK, "FCM 토큰 재발급 여부를 성공적으로 확인했습니다."),
     FCM_TOKEN_UPDATED(HttpStatus.CREATED, "FCM 토큰이 성공적으로 업데이트되었습니다."),
-    USER_CREATED(HttpStatus.CREATED, "유저가 성공적으로 생성되었습니다.")
+    USER_CREATED(HttpStatus.CREATED, "유저가 성공적으로 생성되었습니다."),
+    PUSH_STATUS_UPDATED(HttpStatus.OK, "유저 푸시알림 허용 여부 변경이 성공적으로 업데이트 되었습니다."),
+    USER_NAME_UPDATED(HttpStatus.OK, "유저이름이 성공적으로 업데이트 되었습니다."),
+    USER_DELETED(HttpStatus.OK, "유저가 성공적으로 삭제되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/terning/user/domain/User.java
+++ b/src/main/java/org/terning/user/domain/User.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.terning.fcm.validate.FcmTokenValidator;
 import org.terning.global.entity.BaseEntity;
 import org.terning.notification.domain.Notification;
@@ -35,6 +36,7 @@ public class User extends BaseEntity {
 
     private Long oUserId;
 
+    @Setter
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "name"))
     private UserName name;
@@ -43,6 +45,7 @@ public class User extends BaseEntity {
     @AttributeOverride(name = "value", column = @Column(name = "token"))
     private FcmToken token;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     private PushNotificationStatus pushStatus;
 
@@ -112,4 +115,5 @@ public class User extends BaseEntity {
     public void updateFcmToken(String newTokenValue) {
         this.token = token.updateValue(newTokenValue);
     }
+
 }

--- a/src/main/java/org/terning/user/domain/UserRepository.java
+++ b/src/main/java/org/terning/user/domain/UserRepository.java
@@ -1,7 +1,6 @@
 package org.terning.user.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 }

--- a/src/main/java/org/terning/user/domain/UserRepositoryCustom.java
+++ b/src/main/java/org/terning/user/domain/UserRepositoryCustom.java
@@ -2,8 +2,11 @@ package org.terning.user.domain;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface UserRepositoryCustom {
     Map<Long, User> findUsersByIds(List<Long> userIds);
+
+    Optional<User> findByOUserId(Long oUserId);
 }
 

--- a/src/main/java/org/terning/user/domain/UserRepositoryImpl.java
+++ b/src/main/java/org/terning/user/domain/UserRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.terning.user.domain;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -24,5 +25,16 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .stream()
                 .collect(Collectors.toMap(User::getId, Function.identity()));
     }
+
+    @Override
+    public Optional<User> findByOUserId(Long oUserId) {
+        QUser user = QUser.user;
+        return Optional.ofNullable(
+                queryFactory.selectFrom(user)
+                        .where(user.oUserId.eq(oUserId))
+                        .fetchOne()
+        );
+    }
+
 }
 

--- a/src/test/java/org/terning/user/domain/UserRepositoryTest.java
+++ b/src/test/java/org/terning/user/domain/UserRepositoryTest.java
@@ -197,4 +197,9 @@ public class UserRepositoryTest implements UserRepository, UserRepositoryCustom 
     public Page<User> findAll(Pageable pageable) {
         return Page.empty();
     }
+
+    @Override
+    public Optional<User> findByOUserId(Long oUserId) {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #62 

# 📄 Work Description
- 유저 상태(푸시알림 허용 여부, 유저 이름 변경, 회원 탈퇴) 시 알림서버 <> 운영서버 동기화를 구현했습니다.
- 운영서버에서 동기화 할 값들에 대한 API 요청이 들어오면, 알림서버에서 해당 API를 호출하여 알림서버의 DB를 동기화 하도록 하였습니다.
- 스케쥴링은 아래와 같이 설정했습니다.
  - 푸시 알림(추천 알림)이 오후 1시에 전송되기 30분 전에 사용자 정보 업데이트를 반영하기 위해서 매주 목요일과 토요일 오후 12시 30분에 동기화가 진행되도록 하였습니다.
  - 일요일 오후 9시에 전송되는 트렌딩 알림 전에 업데이트가 반영되도록 하기 위해서 매주 일요일 오후 8시 30분에 동기화가 진행되도록 설정했습니다.

# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
