### PR TITLE
[🔨 Fix] 푸시알림 서버 QA를 위한 코드 수정 및 요구사항 고도화

### DIFF
--- a/src/main/java/org/terning/notification/api/NotificationController.java
+++ b/src/main/java/org/terning/notification/api/NotificationController.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/notifications")
+@RequestMapping("/api/v1/notification")
 public class NotificationController {
 
     private final NotificationService notificationService;

--- a/src/main/java/org/terning/notification/application/writer/NotificationWriterImpl.java
+++ b/src/main/java/org/terning/notification/application/writer/NotificationWriterImpl.java
@@ -33,9 +33,9 @@ public class NotificationWriterImpl implements NotificationWriter {
     public void write(MessageTemplateType template, ScheduledTime sendTime) {
         List<User> targetUsers = fetchTargetUsers(template.targetType());
         List<User> filteredUsers = targetUsers.stream()
-                .filter(user -> user.getToken() != null
-                        && user.getToken().value() != null
-                        && !user.getToken().value().trim().isEmpty())
+                .filter(user -> user.getToken() != null)
+                .filter(user -> user.getToken().value() != null)
+                .filter(user -> !user.getToken().value().trim().isEmpty())
                 .toList();
         List<Notification> notifications = createNotifications(filteredUsers, template, sendTime);
         saveNotifications(notifications);

--- a/src/main/java/org/terning/notification/application/writer/NotificationWriterImpl.java
+++ b/src/main/java/org/terning/notification/application/writer/NotificationWriterImpl.java
@@ -37,11 +37,15 @@ public class NotificationWriterImpl implements NotificationWriter {
     }
 
     private List<User> fetchTargetUsers(MessageTargetType targetType) {
-        return switch (targetType) {
+        List<User> users = switch (targetType) {
             case SCRAPPED_USER -> scrapRepository.findDistinctScrappedUsers();
             case ALL_USERS -> userRepository.findAll();
             default -> throw new NotificationException(NotificationErrorCode.INVALID_TARGET_TYPE);
         };
+
+        return users.stream()
+                .filter(User::canReceivePushNotification)
+                .toList();
     }
 
     private List<Notification> createNotifications(List<User> users, MessageTemplateType template, ScheduledTime sendTime) {

--- a/src/main/java/org/terning/notification/application/writer/NotificationWriterImpl.java
+++ b/src/main/java/org/terning/notification/application/writer/NotificationWriterImpl.java
@@ -32,7 +32,12 @@ public class NotificationWriterImpl implements NotificationWriter {
     @Transactional
     public void write(MessageTemplateType template, ScheduledTime sendTime) {
         List<User> targetUsers = fetchTargetUsers(template.targetType());
-        List<Notification> notifications = createNotifications(targetUsers, template, sendTime);
+        List<User> filteredUsers = targetUsers.stream()
+                .filter(user -> user.getToken() != null
+                        && user.getToken().value() != null
+                        && !user.getToken().value().trim().isEmpty())
+                .toList();
+        List<Notification> notifications = createNotifications(filteredUsers, template, sendTime);
         saveNotifications(notifications);
     }
 

--- a/src/main/java/org/terning/notification/domain/Notification.java
+++ b/src/main/java/org/terning/notification/domain/Notification.java
@@ -15,7 +15,6 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "notifications")
 public class Notification extends BaseEntity {
 
     @Id

--- a/src/main/java/org/terning/scrap/domain/Scrap.java
+++ b/src/main/java/org/terning/scrap/domain/Scrap.java
@@ -10,7 +10,6 @@ import org.terning.global.entity.BaseEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "scraps")
 public class Scrap extends BaseEntity {
 
     @Id

--- a/src/main/java/org/terning/user/api/UserController.java
+++ b/src/main/java/org/terning/user/api/UserController.java
@@ -31,12 +31,12 @@ public class UserController {
         );
     }
 
-    @PostMapping("/{userId}/fcm-tokens")
+    @PutMapping("/{userId}/fcm-tokens")
     public ResponseEntity<SuccessResponse<Void>> updateFcmToken(
             @PathVariable Long userId,
-            @RequestBody UpdateFcmTokenRequest request
+            @RequestBody String newToken
     ) {
-        userService.updateFcmToken(userId, request);
+        userService.updateFcmToken(userId, newToken);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessResponse.of(UserSuccessCode.FCM_TOKEN_UPDATED));
     }

--- a/src/main/java/org/terning/user/application/UserService.java
+++ b/src/main/java/org/terning/user/application/UserService.java
@@ -32,8 +32,11 @@ public class UserService {
     }
 
     @Transactional
-    public void updateFcmToken(Long userId, UpdateFcmTokenRequest request) {
-        fcmTokenUpdateService.updateFcmToken(userId, request.newToken());
+    public void updateFcmToken(Long oUserId, String newToken) {
+        User user = userRepository.findByOUserId(oUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        user.updateFcmToken(newToken);
+        userRepository.save(user);
     }
 
     @Transactional


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #68 

# 📄 Work Description
### 1. `이름 충돌`로 인해 `/api/v1/notification/create`호출 시, `messages`와 `notifications` 테이블에 반영이 되지 않는 오류를 발견했습니다. 이를 해결하기 위해 해당 테이블명을 각각 `message`, `notification`으로 수정했습니다.  

1-1) `/api/v1/notification/create` 호출 시 추가되는 `notification` 테이블 내용 (`유형 2,3` 으로 테스트)
￼
<img width="1104" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/545ed342-4cac-44c0-9ea4-ad9efac7ec63" />
 

1-2) `/api/v1/notification/create` 호출 시 추가되는 `message` 테이블 내용 (`유형 2,3` 으로 테스트)
- 사용자의 이름이 해당 `푸시알림 메세지 > sub`에 정상적으로 반영됨을 확인했습니다.

<img width="1103" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/a2c15b5f-b052-40cc-b005-488e940fdebc" />

1-3) `Postman`으로 정상적으로 해당 `POST` API가 실행됨을 확인했습니다. 
￼
<img width="1073" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/0ebc5714-4c5c-4eea-8284-b9d0894d3859" />

### 2. 전체 대상 푸시알림 발송 시, 정상적으로 발송된 푸시알림의 `sent_status`가 `true`로 변경되도록 설정하였습니다.

2-1) 발송 전 상태 (ID 1과 2 모두 `sent_status`가 `false`)

<img width="1036" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/1b3eb95c-f789-42e2-bb68-39252d062a92" />
￼

2-2) `/api/v1/push-notifications/send-all` 호출하여 전체 대상 푸시알림 발송 (로그로 `2개`가 전송됨을 확인)
￼
<img width="1309" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/c648505a-3f87-44fc-9301-0bf40789b0f1" />


2-3) 발송 후 상태 (ID 1과 2 모두 `sent_status`가 `true`)
￼
<img width="1035" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/11cd3db1-c1ba-46b3-a4d6-03e20f7f2e3f" />


2-4) 만약, `sent_status`가 이미 `true`라면 중복으로 발송되지 않도록 로직을 구현했습니다. (DDL에서 조회만 하고 푸시알림을 발송하지 않음을 확인) 
￼
<img width="1258" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/d60fad0d-376f-4b4e-9344-6bf49bffa95a" />

### 3. 공통적으로 `User`의 `push_status`가 `ENABLED`인 유저만 푸시알림공고가 `create`되도록 로직을 추가했습니다.
￼
<img width="768" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/8a5d80d9-461c-41a5-98df-0c20f08d2268" />

### 4. FCM 토큰의 `길이가 0`이거나, `공백`이거나, `null` 값의 경우 `create`가 되지 않도록 유효성 검증 로직을 추가했습니다.

4-1) `name = “카카오서버QA계정”` 의 `token`값이 빈값이므로 create가 되지 않고, `name = “푸시알림QA”` 만 create 됨을 확인할 수 있다.
￼
<img width="1056" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/586117aa-3dd9-4c7e-a414-163f5501b8a3" />

<img width="1092" alt="Pasted Graphic 10" src="https://github.com/user-attachments/assets/00803653-1bdd-4aca-a7c3-337965adae2d" />

<img width="1107" alt="Pasted Graphic 11" src="https://github.com/user-attachments/assets/ce4de810-f74d-4dd5-bb34-6c97a7544777" />

￼
### 5. 소셜로그인 시, 클라이언트 측에서 `fcmToken`을 `RequestBody`로 전달하도록 하고, 해당 `fcmToken`을 알림서버의 `user > token`값으로 업데이트 하도록 로직을 추가했습니다!
￼
<img width="592" alt="Pasted Graphic 13" src="https://github.com/user-attachments/assets/5429da50-2c0c-42dd-8ccc-c6dc4487cc80" />

<img width="468" alt="Server response" src="https://github.com/user-attachments/assets/0342c59b-80c6-4801-8907-75f75b20cd95" />



# 💬 To Reviewers
- 현재 유효한 fcm토큰을 가지고 있는 유저에게만 전송이 되는 로직이기 떄문에, `다중 유저`에 대한 푸시알림 테스트는 진행하지 못한 상태입니다.
- 현재 유형 1에 대한 푸시알림 구현은 수정이 필요한 상태여서 `유형 2, 3`의 푸시알림 공고에 대한 검증을 위주로 진행했습니다.
- 이후 동기화 관련 로직 검증, 유형 1 로직 검증을 순차적으로 진행할 예정입니다. 



# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
