### PR TITLE
[♻️ refactor/#70] FCM 데이터 페이로드 형식 수정

### DIFF
--- a/src/main/java/org/terning/fcm/application/FcmPushSenderImpl.java
+++ b/src/main/java/org/terning/fcm/application/FcmPushSenderImpl.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.Message;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.terning.message.domain.enums.ViewType;
 import org.terning.notification.domain.Notification;
 import org.terning.user.domain.User;
 
@@ -20,8 +21,12 @@ public class FcmPushSenderImpl implements FcmPushSender {
             User user = notification.getUser();
             String token = user.getToken().value();
 
+            ViewType viewType = ViewType.fromTemplate(notification.getMessage().getMessageTemplateType());
+
             Message fcmMessage = Message.builder()
                     .setToken(token)
+                    .putData("token", token)
+                    .putData("type", notification.getMessage().getViewType())
                     .putData("title", notification.getMessage().getMain())
                     .putData("body", notification.getMessage().getSub())
                     .build();

--- a/src/main/java/org/terning/message/domain/Message.java
+++ b/src/main/java/org/terning/message/domain/Message.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.terning.global.entity.BaseEntity;
 import org.terning.message.domain.enums.MessageTemplateType;
+import org.terning.message.domain.enums.ViewType;
 
 @Entity
 @Getter
@@ -23,14 +24,17 @@ public class Message extends BaseEntity {
 
     private String sub;
 
-    private Message(MessageTemplateType messageTemplateType, String main, String sub) {
+    private String viewType;
+
+    private Message(MessageTemplateType messageTemplateType, String main, String sub, String viewType) {
         this.messageTemplateType = messageTemplateType;
         this.main = main;
         this.sub = sub;
+        this.viewType = viewType;
     }
 
     public static Message of(MessageTemplateType messageTemplateType, String main, String sub) {
-        return new Message(messageTemplateType, main, sub);
+        return new Message(messageTemplateType, main, sub, ViewType.fromTemplate(messageTemplateType).name());
     }
 
     public boolean isSameType(MessageTemplateType other) {

--- a/src/main/java/org/terning/message/domain/enums/ViewType.java
+++ b/src/main/java/org/terning/message/domain/enums/ViewType.java
@@ -1,0 +1,15 @@
+package org.terning.message.domain.enums;
+
+public enum ViewType {
+    CALENDAR,
+    HOME,
+    SEARCH;
+
+    public static ViewType fromTemplate(MessageTemplateType tmpl) {
+        return switch (tmpl) {
+            case INTERESTED_ANNOUNCEMENT_REMINDER -> CALENDAR;
+            case RECENTLY_POSTED_INTERNSHIP_RECOMMENDATION -> HOME;
+            case TRENDING_INTERNSHIP_ALERT -> SEARCH;
+        };
+    }
+}


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #70 

# 📄 Work Description
- 클라이언트에서 푸시알림 클릭 시 이동할 뷰(view)를 구분할 수 있도록, FCM 데이터 페이로드에 `token`, `type`, `title`, `body` 필드를 추가하도록 수정했습니다!

  - MessageTemplateType별로 뷰 타입 코드("CALENDAR", "HOME", "SEARCH") 매핑 로직을 추가했습니다!
  - FcmPushSenderImpl에서 FCM 메시지 빌더에 `token`,` type`,` title`, `body` 데이터 필드 포함시키도록 구현했습니다!!


# 📷 Screenshot
### ✅ 푸시알림 `create` 호출 시, viewType 컬럼 추가로 저장하도록 수정
<img width="993" alt="image" src="https://github.com/user-attachments/assets/bf61487e-f54b-4e2a-9a8a-4820feb367e8" />

### ✅ 푸시알림 전송성공
<img width="1346" alt="image" src="https://github.com/user-attachments/assets/6857fbf4-6c50-43d2-9f10-122bf290d743" />



# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
