### PR TITLE
[♻️ refactor/#72] FCM 데이터 페이로드 형식 수정

### DIFF
--- a/src/main/java/org/terning/fcm/application/FcmPushSenderImpl.java
+++ b/src/main/java/org/terning/fcm/application/FcmPushSenderImpl.java
@@ -21,14 +21,12 @@ public class FcmPushSenderImpl implements FcmPushSender {
             User user = notification.getUser();
             String token = user.getToken().value();
 
-            ViewType viewType = ViewType.fromTemplate(notification.getMessage().getMessageTemplateType());
-
             Message fcmMessage = Message.builder()
                     .setToken(token)
-                    .putData("token", token)
                     .putData("type", notification.getMessage().getViewType())
                     .putData("title", notification.getMessage().getMain())
                     .putData("body", notification.getMessage().getSub())
+                    .putData("imageUrl", notification.getMessage().getImageUrl())
                     .build();
 
             String response = FirebaseMessaging.getInstance().send(fcmMessage);

--- a/src/main/java/org/terning/message/domain/Message.java
+++ b/src/main/java/org/terning/message/domain/Message.java
@@ -26,15 +26,20 @@ public class Message extends BaseEntity {
 
     private String viewType;
 
-    private Message(MessageTemplateType messageTemplateType, String main, String sub, String viewType) {
+    private String imageUrl;
+
+    private Message(MessageTemplateType messageTemplateType, String main, String sub,
+                    String viewType, String imageUrl) {
         this.messageTemplateType = messageTemplateType;
         this.main = main;
         this.sub = sub;
         this.viewType = viewType;
+        this.imageUrl = imageUrl;
     }
 
-    public static Message of(MessageTemplateType messageTemplateType, String main, String sub) {
-        return new Message(messageTemplateType, main, sub, ViewType.fromTemplate(messageTemplateType).name());
+    public static Message of(MessageTemplateType messageTemplateType, String main, String sub, String imageUrl) {
+        return new Message(messageTemplateType, main, sub,
+                ViewType.fromTemplate(messageTemplateType).name(), imageUrl);
     }
 
     public boolean isSameType(MessageTemplateType other) {

--- a/src/main/java/org/terning/message/domain/enums/MessageTemplateType.java
+++ b/src/main/java/org/terning/message/domain/enums/MessageTemplateType.java
@@ -42,6 +42,17 @@ public enum MessageTemplateType {
                 .orElseThrow(() -> new NotificationException(NotificationErrorCode.INVALID_TEMPLATE_TYPE));
     }
 
+    public String getImageUrl() {
+        return switch (this) {
+            case INTERESTED_ANNOUNCEMENT_REMINDER ->
+                    "https://your-cdn.com/images/interested_announcement.png";
+            case RECENTLY_POSTED_INTERNSHIP_RECOMMENDATION ->
+                    "https://your-cdn.com/images/recently_posted_internship.png";
+            case TRENDING_INTERNSHIP_ALERT ->
+                    "https://your-cdn.com/images/trending_internship.png";
+        };
+    }
+
     public String main(Map<String, String> params) {
         return mainMessage.format(params);
     }

--- a/src/main/java/org/terning/notification/application/writer/NotificationWriterImpl.java
+++ b/src/main/java/org/terning/notification/application/writer/NotificationWriterImpl.java
@@ -69,7 +69,8 @@ public class NotificationWriterImpl implements NotificationWriter {
         return Message.of(
                 template,
                 template.main(context),
-                template.sub(context)
+                template.sub(context),
+                template.getImageUrl()
         );
     }
 


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #72 

# 📄 Work Description
- MessageTemplateType별로 동적인 이미지 URL을 설정하여 알림 생성 시점부터 이미지 URL을 포함하도록 수정했습니다!
- createNotification 시 타입별 imageUrl을 저장하도록 추가했습니다.
- sendAllPushNotifications 시 image 데이터를 포함해 푸시알림을 전송할 수 있도록 하였습니다.

# 📷 Screenshot
### ✅ imageUrl 컬럼 추가 및 성공적으로 저장됨
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/02f03b27-2b80-4abb-beb6-0c4d7df82c58" />

### ✅ 푸시알림 발송 성공
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/d8708048-4052-4d91-b93b-de888e1e9764" />


# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
