### PR TITLE
[♻️ refactor] iOS의 APNs를 고려한 FCM 데이터 페이로드 형식 변경

### DIFF
--- a/src/main/java/org/terning/fcm/application/FcmPushSenderImpl.java
+++ b/src/main/java/org/terning/fcm/application/FcmPushSenderImpl.java
@@ -1,5 +1,8 @@
 package org.terning.fcm.application;
 
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.ApsAlert;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -21,12 +24,32 @@ public class FcmPushSenderImpl implements FcmPushSender {
             User user = notification.getUser();
             String token = user.getToken().value();
 
+            String title = notification.getMessage().getMain();
+            String body = notification.getMessage().getSub();
+            String type = notification.getMessage().getViewType();
+            String imageUrl = notification.getMessage().getImageUrl();
+
+            ApsAlert apsAlert = ApsAlert.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build();
+
+            Aps aps = Aps.builder()
+                    .setAlert(apsAlert)
+                    .setMutableContent(true)
+                    .build();
+
+            ApnsConfig apnsConfig = ApnsConfig.builder()
+                    .setAps(aps)
+                    .build();
+
             Message fcmMessage = Message.builder()
                     .setToken(token)
-                    .putData("type", notification.getMessage().getViewType())
-                    .putData("title", notification.getMessage().getMain())
-                    .putData("body", notification.getMessage().getSub())
-                    .putData("imageUrl", notification.getMessage().getImageUrl())
+                    .setApnsConfig(apnsConfig)
+                    .putData("title", title)
+                    .putData("body", body)
+                    .putData("type", type)
+                    .putData("imageUrl", imageUrl)
                     .build();
 
             String response = FirebaseMessaging.getInstance().send(fcmMessage);


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #76 

# 📄 Work Description
아래와 같은 형식으로 Payload가 전송되도록 수정했습니다!
iOS에서는 별도로 APNs 형식을 추가로 보내줘야 해서 해당 설정을 추가했습니다!
```json
{
  "apns": {
    "payload": {
      "aps": {
        "alert": {
          "title": "🎉 새로운 알림이 도착했어요!",
          "body": "지금 확인해보세요."
        },
        "mutable-content": 1
      }
    }
  },
  "data": {
    "title": "🎉 새로운 알림이 도착했어요!",
    "body": "지금 확인해보세요.",
    "type": "calendar",
    "imageUrl": "https://..."
  }
}
```


# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
