### PR TITLE
[♻️ refactor] iOS의 APNs를 고려한 FCM 데이터 페이로드 형식 변경(2)

### DIFF
--- a/src/main/java/org/terning/fcm/application/FcmPushSenderImpl.java
+++ b/src/main/java/org/terning/fcm/application/FcmPushSenderImpl.java
@@ -37,6 +37,8 @@ public class FcmPushSenderImpl implements FcmPushSender {
             Aps aps = Aps.builder()
                     .setAlert(apsAlert)
                     .setMutableContent(true)
+                    .putCustomData("type", type)
+                    .putCustomData("imageUrl", imageUrl)
                     .build();
 
             ApnsConfig apnsConfig = ApnsConfig.builder()
@@ -51,6 +53,8 @@ public class FcmPushSenderImpl implements FcmPushSender {
                     .putData("type", type)
                     .putData("imageUrl", imageUrl)
                     .build();
+
+            log.info("📦 전송된 FCM 메시지: {}", fcmMessage);
 
             String response = FirebaseMessaging.getInstance().send(fcmMessage);
             log.info("FCM 메세지 전송 성공, 응답 ID: {}", response);


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #76 

# 📄 Work Description
아래와 같은 형식으로 Payload가 전송되도록 수정했습니다!
iOS에서는 별도로 APNs 형식을 추가로 보내줘야 해서 해당 설정을 추가했습니다!
```json
{
  "apns": {
    "payload": {
      "aps": {
        "alert": {
          "title": "...",
          "body": "..."
        },
        "mutable-content": 1,
        "type": "...",
        "imageUrl": "..."
      }
    }
  },
  "data": {
    "title": "...",
    "body": "...",
    "type": "...",
    "imageUrl": "..."
  }
}
```


# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
