### PR TITLE
[♻️ refactor/#79] 스크랩 유저를 동기화 시, oUserId를 기준으로 scrap 테이블에 추가되도록 수정

### DIFF
--- a/src/main/java/org/terning/scrap/domain/ScrapRepositoryImpl.java
+++ b/src/main/java/org/terning/scrap/domain/ScrapRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
         return queryFactory
                 .selectDistinct(scrap.user)
                 .from(scrap)
-                .join(scrap.user, user).fetchJoin()
+                .join(scrap.user, user)
                 .where(scrap.status.eq(ScrapStatus.SCRAPPED))
                 .fetch();
     }

--- a/src/main/java/org/terning/user/domain/UserRepositoryCustom.java
+++ b/src/main/java/org/terning/user/domain/UserRepositoryCustom.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 public interface UserRepositoryCustom {
     Map<Long, User> findUsersByIds(List<Long> userIds);
 
+    Map<Long, User> findUsersByOUserIds(List<Long> oUserIds);
+
     Optional<User> findByOUserId(Long oUserId);
 }
 

--- a/src/main/java/org/terning/user/domain/UserRepositoryImpl.java
+++ b/src/main/java/org/terning/user/domain/UserRepositoryImpl.java
@@ -27,6 +27,16 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     @Override
+    public Map<Long, User> findUsersByOUserIds(List<Long> oUserIds) {
+        return queryFactory
+                .selectFrom(QUser.user)
+                .where(QUser.user.oUserId.in(oUserIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(User::getOUserId, Function.identity()));
+    }
+
+    @Override
     public Optional<User> findByOUserId(Long oUserId) {
         QUser user = QUser.user;
         return Optional.ofNullable(


### PR DESCRIPTION
# ⚙️ ISSUE
- closed #79 

# 📄 Work Description
- 스크랩 유저를 동기화 시, `userId`를 기준으로 스크랩 테이블을 추가하게 되어, `빈 리스트`가 반환되고 있었습니다.
- 따라서 `oUserId`를 기준으로 스크랩 동기화가 이루어질 수 있도록 로직을 수정했습니다!
- 중간에 생성되는 스크랩 동기화 유저 수와 알림이 전송되는 수를 빠르게 파악하기 위해, `writer 부분에 log`를 추가했습니다! 이부분은 이후에 QA가 완료된 이후 `삭제할 예정`입니다.

## ✅ 테스트
## 현재 테스트 서버의 유저는 3명
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/bc4da032-1a3a-495f-b00a-63498f7f501e" />

## 3명의 유저 중 1명의 유저만 스크랩을 한 상황(운영서버 userId = 115)
<img width="896" alt="image" src="https://github.com/user-attachments/assets/2284c1f3-b8a9-40d3-8b1b-28ddf77521ef" />

## 스크랩 동기화 실행 (알림서버에 oUserId(운영서버 userId) = 115, userId = 15인 유저의 스크랩 정보 동기화 완료)
### 1. 실행 전
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/99875c2a-557c-4171-acbe-f8dfbc28a091" />

### 2. 실행 후
<img width="1086" alt="image" src="https://github.com/user-attachments/assets/24a10571-dac6-4478-a4fe-6a9ed53eadf1" />
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/7fa36db0-6096-4f23-a0bc-536693f18496" />

## 스크랩한 유저에게만 푸시알림 발송 성공 (스크랩한 유저 1명에게만 푸시알림 발송)
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/76653450-21c3-492f-9bc5-9ddd38df4c1f" />
<img width="846" alt="image" src="https://github.com/user-attachments/assets/a63d09cc-fdfc-41d1-946a-9abb93d76538" />
<img width="847" alt="image" src="https://github.com/user-attachments/assets/657ed95e-2176-4ab0-8029-0ac04e68bad8" />
<img width="824" alt="image" src="https://github.com/user-attachments/assets/c033d46d-7a4a-4e8c-a233-b97a43d29bee" />
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/6f70d1cc-507d-4587-b80d-cbd3488f94b1" />


# ✅ PR check list
- [x] Reviewers
- [x] Assignees
- [x] Labels
